### PR TITLE
Fix transactions order

### DIFF
--- a/src/navigation/component.js
+++ b/src/navigation/component.js
@@ -60,7 +60,7 @@ class RootComponent extends Component {
   componentWillReceiveProps(nextProps) {
     const {
       isInitFromStorageDone, isInitWithParseDone, initializeWithParse,
-      startFetchBalanceTimer, startFetchTransactionTimer, startFetchLatestBlockHeightTimer, walletManager, currency, prices, isBalanceUpdated,
+      startFetchLatestBlockHeightTimer, walletManager, currency, prices, isBalanceUpdated,
       initLiveQueryPrice, initLiveQueryBalances, initLiveQueryTransactions,
     } = nextProps;
 
@@ -102,8 +102,6 @@ class RootComponent extends Component {
       } else {
         // Start timer to get price frequently
         // TODO: we will need to get rid of timer and replace with Push Notification
-        startFetchBalanceTimer(walletManager);
-        startFetchTransactionTimer(walletManager);
         startFetchLatestBlockHeightTimer();
 
         console.log('initLiveQueryPrice', initLiveQueryPrice);
@@ -143,8 +141,6 @@ class RootComponent extends Component {
 RootComponent.propTypes = {
   initializeFromStorage: PropTypes.func.isRequired,
   initializeWithParse: PropTypes.func.isRequired,
-  startFetchBalanceTimer: PropTypes.func.isRequired,
-  startFetchTransactionTimer: PropTypes.func.isRequired,
   startFetchLatestBlockHeightTimer: PropTypes.func.isRequired,
   resetBalanceUpdated: PropTypes.func.isRequired,
   updateWalletAssetValue: PropTypes.func.isRequired,

--- a/src/navigation/component.js
+++ b/src/navigation/component.js
@@ -100,7 +100,6 @@ class RootComponent extends Component {
 
         newState.isStorageRead = true;
       } else {
-        // Start timer to get price frequently
         // TODO: we will need to get rid of timer and replace with Push Notification
         startFetchLatestBlockHeightTimer();
 

--- a/src/navigation/container.js
+++ b/src/navigation/container.js
@@ -29,8 +29,6 @@ const mapDispatchToProps = (dispatch) => ({
   closePasscodeModal: () => dispatch(appActions.hidePasscode()),
   initializeFromStorage: () => dispatch(appActions.initializeFromStorage()),
   initializeWithParse: () => dispatch(appActions.initializeWithParse()),
-  startFetchBalanceTimer: (walletManager) => dispatch(walletActions.startFetchBalanceTimer(walletManager)),
-  startFetchTransactionTimer: (walletManager) => dispatch(walletActions.startFetchTransactionTimer(walletManager)),
   startFetchLatestBlockHeightTimer: () => dispatch(walletActions.startFetchLatestBlockHeightTimer()),
   resetBalanceUpdated: () => dispatch(walletActions.resetBalanceUpdated()),
   updateWalletAssetValue: (currency, prices) => dispatch(walletActions.updateAssetValue(currency, prices)),

--- a/src/redux/wallet/actions.js
+++ b/src/redux/wallet/actions.js
@@ -12,7 +12,7 @@ const actions = {
   RESET_BALANCE_UPDATED: 'RESET_BALANCE_UPDATED',
 
   FETCH_TRANSACTION: 'FETCH_TRANSACTION',
-  FETCH_TRANSACTION_RESULT: 'FETCH_TRANSACTION_RESULT',
+  UPDATE_TRANSACTIONS: 'UPDATE_TRANSACTIONS',
 
   FETCH_LATEST_BLOCK_HEIGHT: 'FETCH_LATEST_BLOCK_HEIGHT',
   FETCH_LATEST_BLOCK_HEIGHT_RESULT: 'FETCH_LATEST_BLOCK_HEIGHT_RESULT',
@@ -79,14 +79,6 @@ const actions = {
   updateAssetValue: (currency, prices) => ({
     type: actions.UPDATE_ASSET_VALUE,
     payload: { currency, prices },
-  }),
-  startFetchBalanceTimer: (walletManager) => ({
-    type: actions.START_FETCH_BALANCE_TIMER,
-    payload: walletManager,
-  }),
-  startFetchTransactionTimer: (walletManager) => ({
-    type: actions.START_FETCH_TRANSACTION_TIMER,
-    payload: walletManager,
   }),
   startFetchLatestBlockHeightTimer: () => ({
     type: actions.START_FETCH_LATEST_BLOCK_HEIGHT_TIMER,

--- a/src/redux/wallet/reducer.js
+++ b/src/redux/wallet/reducer.js
@@ -51,8 +51,8 @@ export default function walletReducer(state = initState, action) {
     case actions.RESET_BALANCE_UPDATED: {
       return state.set('isBalanceUpdated', false);
     }
-    case actions.FETCH_TRANSACTION_RESULT: {
-      const transactions = action.value;
+    case actions.UPDATE_TRANSACTIONS: {
+      const { transactions, operation } = action.value;
       const walletManager = state.get('walletManager');
       const tokens = walletManager.getTokens();
 
@@ -65,7 +65,11 @@ export default function walletReducer(state = initState, action) {
           }
           const txIndex = _.findIndex(newToken.transactions, { hash: transaction.hash });
           if (txIndex === -1) {
-            newToken.transactions.unshift(transaction);
+            if (operation === 'unshift') {
+              newToken.transactions.unshift(transaction);
+            } else {
+              newToken.transactions.push(transaction);
+            }
           } else {
             newToken.transactions[txIndex] = transaction;
           }

--- a/src/redux/wallet/saga.js
+++ b/src/redux/wallet/saga.js
@@ -280,7 +280,14 @@ function createTransactionsSubscriptionChannel(subscription) {
     const updateHandler = (item) => {
       console.log('createTransactionsSubscriptionChannel.updateHandler', item);
       const transaction = parseDataUtil.getTransaction(item);
-      return emitter({ type: actions.FETCH_TRANSACTION_RESULT, value: [transaction] });
+      return emitter({
+        type: actions.UPDATE_TRANSACTIONS,
+        value: {
+          transactions: [transaction],
+          // Because the transaction is updated by the subscription, it is inserted from the head of the list.
+          operation: 'unshift',
+        },
+      });
     };
     const errorHandler = (error) => {
       console.log('createTransactionsSubscriptionChannel.errorHandler', error);
@@ -303,8 +310,11 @@ function* fetchTransactions(tokens) {
   try {
     const transactions = yield call(ParseHelper.fetchTransactions, tokens);
     yield put({
-      type: actions.FETCH_TRANSACTION_RESULT,
-      value: transactions,
+      type: actions.UPDATE_TRANSACTIONS,
+      value: {
+        transactions,
+        operation: 'push',
+      },
     });
   } catch (error) {
     console.log('initLiveQueryTransactionsRequest.fetchTransactions, error:', error);


### PR DESCRIPTION
The previous transaction list was incorrect, and the most recent one came to the tail of list. This PR was modified to fix this problem.

The data returned by fetch is sorted to the end of the list in order, and the data updated by subscription is inserted into the head of the list.