### PR TITLE
Fix the order of transactions

### DIFF
--- a/src/common/common.js
+++ b/src/common/common.js
@@ -430,16 +430,6 @@ const common = {
       return symbolIndexA - symbolIndexB;
     });
   },
-
-  /**
-   * sortTransactions
-   * sort transactions by receivedAt.
-   * @param {Array} transactions, array of objects { receivedAt }
-   * @returns array of sorted transactions
-   */
-  sortTransactions(transactions) {
-    return transactions.sort((a, b) => (a.receivedAt < b.receivedAt ? 1 : -1));
-  },
 };
 
 export default common;

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -430,6 +430,16 @@ const common = {
       return symbolIndexA - symbolIndexB;
     });
   },
+
+  /**
+   * sortTransactions
+   * sort transactions by receivedAt.
+   * @param {Array} transactions, array of objects { receivedAt }
+   * @returns array of sorted transactions
+   */
+  sortTransactions(transactions) {
+    return transactions.sort((a, b) => (a.receivedAt < b.receivedAt ? 1 : -1));
+  },
 };
 
 export default common;

--- a/src/common/parseDataUtil.js
+++ b/src/common/parseDataUtil.js
@@ -9,9 +9,11 @@ const parseDataUtil = {
   getTransaction(txOjbect) {
     const createdAt = txOjbect.get('createdAt');
     const confirmedAt = txOjbect.get('confirmedAt');
+    const receivedAt = txOjbect.get('receivedAt');
     const transaction = {
       createdAt: createdAt ? moment(createdAt) : null,
       confirmedAt: confirmedAt ? moment(confirmedAt) : null,
+      receivedAt,
       chain: txOjbect.get('chain'),
       type: txOjbect.get('type'),
       from: txOjbect.get('from'),

--- a/src/redux/wallet/saga.js
+++ b/src/redux/wallet/saga.js
@@ -9,7 +9,6 @@ import appActions from '../app/actions';
 import ParseHelper from '../../common/parse';
 import CoinSwitchHelper from '../../common/coinswitch.helper';
 import parseDataUtil from '../../common/parseDataUtil';
-import common from '../../common/common';
 
 import { createErrorNotification } from '../../common/notification.controller';
 
@@ -209,16 +208,18 @@ function* initLiveQueryBalancesRequest(action) {
   yield call(subscribeBalances, tokens);
 }
 
-
-function addTokenTransaction(token, transaction) {
+function addTokenTransactions(token, transactions) {
   const newToken = token;
   newToken.transactions = newToken.transactions || [];
-  const txIndex = _.findIndex(newToken.transactions, { hash: transaction.hash });
-  if (txIndex === -1) {
-    newToken.transactions.push(transaction);
-  } else {
-    newToken.transactions[txIndex] = transaction;
-  }
+  _.each(transactions, (transaction) => {
+    const txIndex = _.findIndex(newToken.transactions, { hash: transaction.hash });
+    if (txIndex === -1) {
+      newToken.transactions.push(transaction);
+    } else {
+      newToken.transactions[txIndex] = transaction;
+    }
+  });
+  newToken.transactions = newToken.transactions.sort((a, b) => (a.receivedAt < b.receivedAt ? 1 : -1));
 }
 
 function* updateTransactionRequest(action) {
@@ -231,9 +232,7 @@ function* updateTransactionRequest(action) {
    && item.type === transaction.type
    && (item.address === transaction.from || item.address === transaction.to));
   _.each(foundTokens, (token) => {
-    const newToken = token;
-    addTokenTransaction(token, transaction);
-    newToken.transactions = common.sortTransactions(newToken.transactions);
+    addTokenTransactions(token, [transaction]);
   });
   return put({ type: actions.WALLETS_UPDATED });
 }
@@ -281,10 +280,7 @@ function* fetchTransactions(action) {
   try {
     const transactions = yield call(ParseHelper.fetchTransactions, symbol, address, skipCount, fetchCount);
     token.transactions = token.transactions || [];
-    _.each(transactions, (transaction) => {
-      addTokenTransaction(token, transaction);
-    });
-    token.transactions = common.sortTransactions(token.transactions);
+    addTokenTransactions(token, transactions);
   } catch (error) {
     console.log('initLiveQueryTransactionsRequest.fetchTransactions, error:', error);
   } finally {


### PR DESCRIPTION
修复以下情况下的bug:
1. 用户进入列表，页面会自动获取前10条信息。
2. 用户发送一笔交易，此时刚好live query断线，一段时间重连成功后，那笔交易未能通过live query更新到列表中。
3. 当用户再次进入列表，页面再次自动获取前10条信息（包含刚刚发送出去的那条交易），按之前的规则，新交易会被push到列表尾部。

解决方法：
每次fetch或update transactions时，需要对transactions按receivedAt进行排序。因为之前的数组已经是有序的，则按快速排序的方法，算法复杂度会是O(n)，n为token.transactions.length（已在列表中元素数量），且只是更新transactions时调用，是可接受的。
