### PR TITLE
Fix balance in transaction detail

### DIFF
--- a/src/pages/wallet/transaction.js
+++ b/src/pages/wallet/transaction.js
@@ -87,28 +87,31 @@ class Transaction extends Component {
 
   static processViewData(transation, latestBlockHeights) {
     const { rawTransaction } = transation;
+    const {
+      chain, symbol, type, value, blockHeight, hash, memo,
+    } = rawTransaction;
     let amountText = null;
     if (!_.isNil(rawTransaction.value)) {
-      const amount = common.convertUnitToCoinAmount(rawTransaction.symbol, rawTransaction.value);
-      amountText = `${common.getBalanceString(amount, transation.symbol)} ${common.getSymbolName(rawTransaction.symbol, rawTransaction.type)}`;
+      const amount = common.convertUnitToCoinAmount(symbol, value);
+      amountText = `${common.getBalanceString(amount, symbol)} ${common.getSymbolName(symbol, type)}`;
     }
     const datetimeText = transation.datetime ? transation.datetime.format('MMM Do YYYY HH:mm:ss A ZZ') : '';
     let confirmations = strings('page.wallet.transaction.Unconfirmed');
     if (transation.state === 'Sent' || transation.state === 'Received') {
-      let latestBlockHeight = common.getLatestBlockHeight(latestBlockHeights, rawTransaction.chain, rawTransaction.type);
+      let latestBlockHeight = common.getLatestBlockHeight(latestBlockHeights, chain, type);
       latestBlockHeight = _.isNil(latestBlockHeight) ? 0 : latestBlockHeight;
-      confirmations = latestBlockHeight - rawTransaction.blockHeight;
+      confirmations = latestBlockHeight - blockHeight;
       confirmations = confirmations < 0 ? 0 : confirmations;
       confirmations = confirmations >= 6 ? '6+' : confirmations;
     }
     return {
       transactionState: transation.state,
-      transactionId: rawTransaction.hash,
+      transactionId: hash,
       amount: amountText,
       stateIcon: stateIcons[transation.state],
       datetime: datetimeText,
       confirmations,
-      memo: rawTransaction.memo || strings('page.wallet.transaction.noMemo'),
+      memo: memo || strings('page.wallet.transaction.noMemo'),
       title: `${transation.state} Funds`,
       isRefreshing: false,
     };


### PR DESCRIPTION
之前这个界面的余额显示不正确，显示为0。
v1.1.1测试时发现，并修复了。

![image](https://user-images.githubusercontent.com/16951509/82778272-80fa1980-9e83-11ea-8e85-eff7644cc806.png)
