### PR TITLE
Fix transaction ordering issue. Fix #171

### DIFF
--- a/src/common/parse.js
+++ b/src/common/parse.js
@@ -269,7 +269,7 @@ class ParseHelper {
     queryTo.equalTo('to', address);
     const querySymbol = new Parse.Query(ParseTransaction);
     querySymbol.equalTo('symbol', symbol);
-    const query = Parse.Query.and(Parse.Query.or(queryFrom, queryTo), querySymbol).descending('receivedAt');
+    const query = Parse.Query.and(Parse.Query.or(queryFrom, queryTo), querySymbol).descending('createdAt');
     const results = await query.skip(skipCount).limit(fetchCount).find();
     const transactions = _.map(results, (item) => {
       const transaction = parseDataUtil.getTransaction(item);

--- a/src/redux/wallet/saga.js
+++ b/src/redux/wallet/saga.js
@@ -219,7 +219,7 @@ function addTokenTransactions(token, transactions) {
       newToken.transactions[txIndex] = transaction;
     }
   });
-  newToken.transactions = newToken.transactions.sort((a, b) => (a.receivedAt < b.receivedAt ? 1 : -1));
+  newToken.transactions = newToken.transactions.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
 }
 
 function* updateTransactionRequest(action) {


### PR DESCRIPTION
Fix issue #171: Transaction History ordering is not consistent

1. First send 1 RIF, then send 2 RIF
<img width="405" alt="截屏2020-05-25 下午4 09 29" src="https://user-images.githubusercontent.com/25864116/82792698-5a97a680-9ea2-11ea-99c5-70124634911b.png">

2. 1 RIF transaction has been confirmed, and 2 RIF transaction is still sending
<img width="408" alt="截屏2020-05-25 下午4 09 43" src="https://user-images.githubusercontent.com/25864116/82792704-5d929700-9ea2-11ea-8ca3-2153550f4345.png">

3. 2 RIF transaction has been confirmed.
<img width="400" alt="截屏2020-05-25 下午4 10 51" src="https://user-images.githubusercontent.com/25864116/82792712-608d8780-9ea2-11ea-8523-4cde89a29ac7.png">

