### PR TITLE
Fix webview

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -188,6 +188,7 @@ dependencies {
     implementation "com.google.firebase:firebase-core:16.0.6"
     implementation "com.google.firebase:firebase-messaging:17.3.3"
     implementation 'com.android.support:multidex:1.0.3'
+    implementation project(':react-native-webview')
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
+++ b/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
@@ -31,6 +31,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.reactnativecommunity.slider.ReactSliderPackage;
+import com.reactnativecommunity.webview.RNCWebViewPackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -66,7 +67,8 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
             new RNScreensPackage(),
             new ReactSliderPackage(),
             new RNFirebaseMessagingPackage(),
-            new RNFirebaseNotificationsPackage()
+            new RNFirebaseNotificationsPackage(),
+            new RNCWebViewPackage()
       );
     }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -37,5 +37,7 @@ include ':react-native-gesture-handler'
 project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 include ':react-native-screens'
 project(':react-native-screens').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-screens/android')
+include ':react-native-webview'
+project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
 
 include ':app'

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-native-uuid-generator": "^6.1.1",
     "react-native-vector-icons": "^6.6.0",
     "react-native-version-number": "^0.3.6",
-    "react-native-webview": "^9.2.2",
+    "react-native-webview": "9.4.0",
     "react-navigation": "^3.11.0",
     "react-redux": "^7.1.0",
     "react-router-redux": "^4.0.8",

--- a/src/components/common/webview.modal.js
+++ b/src/components/common/webview.modal.js
@@ -10,6 +10,7 @@ const WebViewModal = ({
   <Modal
     animationType="slide"
     visible={visible}
+    onRequestClose={onBackButtonPress}
   >
     <View style={{ flex: 1 }}>
       <OperationHeader title={title} onBackButtonPress={onBackButtonPress} />

--- a/src/pages/mine/index.js
+++ b/src/pages/mine/index.js
@@ -17,6 +17,7 @@ import RSKad from '../../components/common/rsk.ad';
 import BasePageGereral from '../base/base.page.general';
 import HeaderMineIndex from '../../components/headers/header.mineindex';
 import presetStyles from '../../assets/styles/style';
+import WebViewModal from '../../components/common/webview.modal';
 import config from '../../../config';
 import color from '../../assets/styles/color.ts';
 
@@ -264,7 +265,7 @@ class MineIndex extends Component {
       title: 'page.start.terms.termsOfUse',
       icon: <AntDesign name="filetext1" size={22} style={[styles.communityIcon, styles.grayIcon]} />,
       onPress: () => {
-        Linking.openURL(config.termsUrl).catch((err) => console.error('Cannot open Terms of Use: ', err));
+        this.setState({ isTermsWebViewVisible: true });
       },
     },
   ];
@@ -275,6 +276,7 @@ class MineIndex extends Component {
       keyListData: [],
       settings: [],
       joins: [],
+      isTermsWebViewVisible: false,
     };
     this.onEditNamePress = this.onEditNamePress.bind(this);
   }
@@ -302,10 +304,14 @@ class MineIndex extends Component {
     navigation.navigate('Rename');
   }
 
+  onViewTermsPressed = () => {
+    this.setState({ isTermsWebViewVisible: true });
+  }
+
   render() {
     const { language, navigation, username } = this.props;
     const {
-      keyListData, settings, joins,
+      keyListData, settings, joins, isTermsWebViewVisible,
     } = this.state;
     // Translate If username is default user name
     const usernameText = _.isEmpty(username) ? strings('page.mine.index.anonymousUser') : username;
@@ -355,6 +361,12 @@ class MineIndex extends Component {
             />
           </View>
         </View>
+        <WebViewModal
+          title={strings('page.start.terms.termsOfUse')}
+          url={config.termsUrl}
+          visible={isTermsWebViewVisible}
+          onBackButtonPress={() => { this.setState({ isTermsWebViewVisible: false }); }}
+        />
       </BasePageGereral>
     );
   }

--- a/src/pages/start/terms.js
+++ b/src/pages/start/terms.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import {
-  View, Image, StyleSheet, TouchableOpacity, Linking,
+  View, Image, StyleSheet, TouchableOpacity,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -9,6 +9,8 @@ import Loc from '../../components/common/misc/loc';
 import TermRow from './term.row';
 import SafeAreaView from '../../components/common/misc/safe.area.view';
 import screenHelper from '../../common/screenHelper';
+import WebViewModal from '../../components/common/webview.modal';
+import { strings } from '../../common/i18n';
 import config from '../../../config';
 import color from '../../assets/styles/color.ts';
 
@@ -51,16 +53,24 @@ class TermsPage extends Component {
     header: null,
   });
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      isTermsWebViewVisible: false,
+    };
+  }
+
   onButtonPressed = () => {
     const { navigation } = this.props;
     navigation.navigate('PrimaryTabNavigator');
   }
 
   onViewTermsPressed = () => {
-    Linking.openURL(config.termsUrl).catch((err) => console.error('Cannot open Terms of Use: ', err));
+    this.setState({ isTermsWebViewVisible: true });
   }
 
   render() {
+    const { isTermsWebViewVisible } = this.state;
     return (
       <SafeAreaView>
         <View style={styles.page}>
@@ -83,6 +93,12 @@ class TermsPage extends Component {
             />
           </View>
         </View>
+        <WebViewModal
+          title={strings('page.start.terms.termsOfUse')}
+          url={config.termsUrl}
+          visible={isTermsWebViewVisible}
+          onBackButtonPress={() => { this.setState({ isTermsWebViewVisible: false }); }}
+        />
       </SafeAreaView>
     );
   }


### PR DESCRIPTION
实际上react-native-webview使用的是androidx支持库，我们使用的react-native 0.59.10不支持androidx，但是使用`jetifier -r`可以将androidx替换为android.support.v4的库。
如果编译时出现
```
/Users/star/devlab/rwallet/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java:14: 错误: 找不到符号
import androidx.annotation.RequiresApi;
                          ^
  符号:   类 RequiresApi
  位置: 程序包 androidx.annotation
/Users/star/devlab/rwallet/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java:15: 错误: 程序包androidx.core.content不存在
import androidx.core.content.ContextCompat;
```
我们可以运行`npm run postinstall`去解决。

![image](https://user-images.githubusercontent.com/16951509/82825216-6c4a6f80-9edd-11ea-8357-6282bb0399ca.png)

