### PR TITLE
Add AndroidX support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
+++ b/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
@@ -2,8 +2,8 @@ package com.rsk.rwallet.reactnative;
 
 import android.app.Application;
 import android.content.Context;
-import android.support.multidex.MultiDex;
-import android.support.multidex.MultiDexApplication;
+import androidx.multidex.MultiDex;
+import androidx.multidex.MultiDexApplication;
 
 import com.facebook.react.ReactApplication;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,3 +22,6 @@
 # MYAPP_UPLOAD_KEY_ALIAS=key0
 # MYAPP_UPLOAD_STORE_PASSWORD=
 # MYAPP_UPLOAD_KEY_PASSWORD=
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -13252,6 +13252,11 @@
         "react-native-measureme": "0.0.2"
       }
     },
+    "react-native-device-info": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-5.6.3.tgz",
+      "integrity": "sha512-fmaXRjG0NW9FAOdOD86cmjgoxA/2I0lBq1NZmxQ2sgElyRjLxZLtuJn/QpP8hmFeTlKFDSZpSDvEnB+UUihcmw=="
+    },
     "react-native-dotenv": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-0.2.0.tgz",
@@ -13278,9 +13283,9 @@
       }
     },
     "react-native-fingerprint-scanner": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/react-native-fingerprint-scanner/-/react-native-fingerprint-scanner-2.6.2.tgz",
-      "integrity": "sha512-7mXqE9GUiK+Bh5sG+aVq1RGV94Z0PPl6qTibh6i4+ApZ3DU3HxsJ2di7vHTvZsJ1YfmQCHmQIXs4bNuwp20wEg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fingerprint-scanner/-/react-native-fingerprint-scanner-6.0.0.tgz",
+      "integrity": "sha512-8VoKSA0Z0kWnIni96yABZfUUzfmWFXQEXcELwWr1CNLloPt3WoPptYb/6pGsBcH0YxSsW3X4+C8tl0clgyBsvA=="
     },
     "react-native-fs": {
       "version": "2.16.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "postinstall": "jetifier -r",
+    "postinstall": "jetifier",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "android": "react-native run-android",
     "buildandroid": "cd android && ./gradlew assembleRelease",
@@ -46,7 +46,7 @@
     "react-native-dash": "0.0.11",
     "react-native-device-info": "^5.6.3",
     "react-native-dotenv": "^0.2.0",
-    "react-native-fingerprint-scanner": "^2.6.2",
+    "react-native-fingerprint-scanner": "^6.0.0",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-i18n": "^2.0.15",

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -308,11 +308,11 @@ const common = {
   async getBiometryType() {
     try {
       const biometryType = await FingerprintScanner.isSensorAvailable();
-      if (biometryType === BIOMETRY_TYPES.TOUCH_ID || biometryType === BIOMETRY_TYPES.FINGERPRINT || biometryType === BIOMETRY_TYPES.FACE_ID) {
+      if (biometryType === BIOMETRY_TYPES.TOUCH_ID || biometryType === BIOMETRY_TYPES.FACE_ID || biometryType === BIOMETRY_TYPES.Biometrics) {
         return biometryType;
       }
     } catch (error) {
-      console.log('The device does not support fingerprint');
+      console.log('The device does not support fingerprint, error: ', error);
     }
     return null;
   },

--- a/src/common/constants.json
+++ b/src/common/constants.json
@@ -19,7 +19,7 @@
 
   "BIOMETRY_TYPES": {
     "TOUCH_ID": "Touch ID",
-    "FINGERPRINT": "Fingerprint",
-    "FACE_ID": "Face ID"
+    "FACE_ID": "Face ID",
+    "Biometrics": "Biometrics"
   }
 }

--- a/src/common/translations/zh.json
+++ b/src/common/translations/zh.json
@@ -417,7 +417,7 @@
       "fingerprint": {
         "title": "指纹解锁",
         "touchToVerify": "点击进行指纹解锁",
-        "nativeNote": "通过Home键验证已有手机指纹",
+        "nativeNote": "请验证已有指纹",
         "notMatch": "指纹不匹配，请重试。"
       },
       "faceID": {

--- a/src/components/common/modal/touchSensorModal.js
+++ b/src/components/common/modal/touchSensorModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import {
-  View, StyleSheet, Image, TouchableOpacity, Platform,
+  View, StyleSheet, Image, TouchableOpacity,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import FingerprintScanner from 'react-native-fingerprint-scanner';
@@ -133,6 +133,7 @@ export default class TouchSensorModal extends Component {
       onAttempt,
       description: biometryType === BIOMETRY_TYPES.FACE_ID ? strings('modal.touchSensor.faceID.nativeNote') : strings('modal.touchSensor.fingerprint.nativeNote'),
       fallbackEnabled: false,
+      cancelButton: strings('button.cancel'),
     };
     FingerprintScanner.authenticate(params).then(() => {
       this.setState({ errorMessage: null });
@@ -178,13 +179,10 @@ export default class TouchSensorModal extends Component {
           <TouchableOpacity
             style={styles.finger}
             onPress={this.onIconPressed}
-            disabled={!(Platform.OS === 'ios')}
           >
             <Image source={finger} />
           </TouchableOpacity>
-          { Platform.OS === 'ios' && (
-            <Loc style={[styles.touchToVerify]} text={touchToVerifyText} />
-          )}
+          <Loc style={[styles.touchToVerify]} text={touchToVerifyText} />
 
           {
             !fingerprintPasscodeDisabled && (


### PR DESCRIPTION
因为旧版本react-native-device-info:2.3.2含UIWebView会影响到iOS提交，新版本5.6.3必须使用AndroidX。
为了支持AndroidX，做了如下配置和修改。

1. 通过jetifier将android.support.v4转成AndroidX
1. 配置gradle.properties使用AndroidX
```
android.useAndroidX=true
android.enableJetifier=true
```
3. 修改react-native-fingerprint-scanner到6.0.0版本，支持AndroidX 
react-native-fingerprint-scanner:6.0.0与旧版本不同的是会弹出这个界面进行指纹验证。

![image](https://user-images.githubusercontent.com/16951509/88876020-f2c05c00-d254-11ea-859e-fcc478b3734e.png)
