### PR TITLE
fix rif faucet issue. Fix #353

### DIFF
--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -311,6 +311,7 @@ class DAppBrowser extends Component {
           callAuthVerify(async () => {
             try {
               let nonce = await this.provider.getTransactionCount(address);
+              // Some transactions are not on the chain yet, so need save local nonce to ensure that the transaction nonce is unique
               if (localNonce > nonce) {
                 nonce = localNonce;
               }

--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -41,7 +41,6 @@ class DAppBrowser extends Component {
       wallet: this.generateWallet(currentWallet),
       web3JsContent: '',
       ethersJsContent: '',
-      localNonce: 0,
     };
 
     this.webview = createRef();
@@ -258,7 +257,6 @@ class DAppBrowser extends Component {
     const { data } = event.nativeEvent;
     const payload = JSON.parse(data);
     const { method, params, id } = payload;
-    const { localNonce } = this.state;
     try {
       const { callAuthVerify } = this.props;
       const { wallet: { coins, address } } = this.state;
@@ -310,12 +308,7 @@ class DAppBrowser extends Component {
         case 'eth_sendTransaction': {
           callAuthVerify(async () => {
             try {
-              let nonce = await this.provider.getTransactionCount(address);
-              // Some transactions are not on the chain yet, so need save local nonce to ensure that the transaction nonce is unique
-              if (localNonce > nonce) {
-                nonce = localNonce;
-              }
-              this.setState({ localNonce: nonce + 1 });
+              const nonce = await this.provider.getTransactionCount(address, 'pending');
               const txData = {
                 nonce,
                 data: params[0].data,


### PR DESCRIPTION
是nonce造成的bug。当我第一次发送交易成功之后，马上发送第二次交易，这时候从链上取到的nonce，还是上一笔交易的nonce（可能是因为上一笔交易还没有上链），所以造成交易失败。
本地发送的交易，需要把nonce保存到一个变量，当本地的nonce大于链上取回的nonce的时候，就优先使用本地的nonce值。