### PR TITLE
fix rns get result issue

### DIFF
--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -234,8 +234,14 @@ class DAppBrowser extends Component {
               callback(err, res)
             }
 
-            window.ethereum.send = sendAsync
-            window.ethereum.sendAsync = sendAsync
+            setTimeout(() => {
+              if (!window.ethereum.send) {
+                window.ethereum.send = sendAsync
+              }
+              if (!window.ethereum.sendAsync) {
+                window.ethereum.sendAsync = sendAsync
+              }
+            }, 1000)
           }
 
           initWeb3()

--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -234,6 +234,7 @@ class DAppBrowser extends Component {
               callback(err, res)
             }
 
+            // ensure window.ethereum.send and window.ethereum.sendAsync are not undefined
             setTimeout(() => {
               if (!window.ethereum.send) {
                 window.ethereum.send = sendAsync


### PR DESCRIPTION
修复RNS Dapp中，window.ethereum.send和window.ethereum.send这两个方法有时候是undefined的问题，会造成RNS在注册domain的时候，会一直在转圈，获取不到结果，实际上是已经完成的问题。