### PR TITLE
change custom token decimals from 3 to 6. Fix #498

### DIFF
--- a/config.js
+++ b/config.js
@@ -50,7 +50,7 @@ const config = {
     RBTC: 6,
     RIF: 3,
     DOC: 3,
-    CustomToken: 3,
+    CustomToken: 6,
   },
   assetValueDecimalPlaces: 2,
   transactionUrls: {
@@ -100,7 +100,5 @@ const config = {
   storageVersion: 3,
   defaultDappIcon: 'https://storage.googleapis.com/storage-rwallet/rwallet.png',
 };
-
-
 
 export default config;


### PR DESCRIPTION
When the custom token decimal is 3, "0.00027" will show "0".
Set the custom token decimals to 6 could fix this issue.

<img width="405" alt="CleanShot 2020-09-28 at 13 44 27@2x" src="https://user-images.githubusercontent.com/25864116/94394870-f575f980-0190-11eb-829e-69e75c2250af.png">
