### PR TITLE
Fix share issue. fix #512

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -164,7 +164,6 @@ dependencies {
     implementation project(':react-native-device-info')
     implementation project(':@imstar15_react-native-firebase')
     implementation project(':react-native-fs')
-    implementation project(':react-native-view-shot')
     implementation project(':react-native-share')
     implementation project(':react-native-spring-scrollview')
     implementation project(':@react-native-community_blur')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -161,6 +161,7 @@ android {
 }
 
 dependencies {
+    implementation project(':react-native-view-shot')
     implementation project(':react-native-device-info')
     implementation project(':@imstar15_react-native-firebase')
     implementation project(':react-native-fs')

--- a/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
+++ b/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
@@ -6,6 +6,7 @@ import androidx.multidex.MultiDex;
 import androidx.multidex.MultiDexApplication;
 
 import com.facebook.react.ReactApplication;
+import fr.greweb.reactnativeviewshot.RNViewShotPackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import io.invertase.firebase.RNFirebasePackage;
 import com.rnfs.RNFSPackage;
@@ -52,6 +53,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNViewShotPackage(),
             new RNDeviceInfo(),
             new RNFirebasePackage(),
             new RNFSPackage(),

--- a/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
+++ b/android/app/src/main/java/com/rsk/rwallet/reactnative/MainApplication.java
@@ -9,7 +9,6 @@ import com.facebook.react.ReactApplication;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import io.invertase.firebase.RNFirebasePackage;
 import com.rnfs.RNFSPackage;
-import fr.greweb.reactnativeviewshot.RNViewShotPackage;
 import cl.json.RNSharePackage;
 import com.bolan9999.SpringScrollViewPackage;
 import com.cmcewen.blurview.BlurViewPackage;
@@ -56,7 +55,6 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
             new RNDeviceInfo(),
             new RNFirebasePackage(),
             new RNFSPackage(),
-            new RNViewShotPackage(),
             new RNSharePackage(),
             new SpringScrollViewPackage(),
             new BlurViewPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,8 +5,6 @@ include ':@imstar15_react-native-firebase'
 project(':@imstar15_react-native-firebase').projectDir = new File(rootProject.projectDir, '../node_modules/@imstar15/react-native-firebase/android')
 include ':react-native-fs'
 project(':react-native-fs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fs/android')
-include ':react-native-view-shot'
-project(':react-native-view-shot').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-view-shot/android')
 include ':react-native-share'
 project(':react-native-share').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-share/android')
 include ':react-native-spring-scrollview'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'rwallet'
+include ':react-native-view-shot'
+project(':react-native-view-shot').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-view-shot/android')
 include ':react-native-device-info'
 project(':react-native-device-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
 include ':@imstar15_react-native-firebase'

--- a/ios/rwallet.xcodeproj/project.pbxproj
+++ b/ios/rwallet.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00AD644EF595416DA8E09C2E /* libRNSpringScrollView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B7002C49DAAA4AB4BE86FEB4 /* libRNSpringScrollView.a */; };
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
@@ -86,7 +87,6 @@
 		F6C97E6D26A040A4B1528430 /* libRNScreens.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E38FF2A9515D47FCB3EB54E1 /* libRNScreens.a */; };
 		F6FDF0F767AF4A63B18B8CCF /* libRNBlur.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA1CFA1F7DCF4BF2B6663221 /* libRNBlur.a */; };
 		F7CF80E724A7ED1D005CF2D5 /* web3.1.2.7.js in Resources */ = {isa = PBXBuildFile; fileRef = F7CF80E624A7ED1D005CF2D5 /* web3.1.2.7.js */; };
-		F7CF80E924A8C651005CF2D5 /* ethers.js in Resources */ = {isa = PBXBuildFile; fileRef = F7CF80E824A8C650005CF2D5 /* ethers.js */; };
 		F8B745FF247BB9D4005AB80B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8B74601247BB9D4005AB80B /* InfoPlist.strings */; };
 		F8B97ABA238F9EC3000F3BFD /* libRNCamera.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F8B97AB9238F9E8D000F3BFD /* libRNCamera.a */; };
 		F8D5F45D238B92E2006CFB8D /* Fontisto.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F8D5F44D238B92E2006CFB8D /* Fontisto.ttf */; };
@@ -722,7 +722,6 @@
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		F3AA2513C79C4BF28F9CFA74 /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
 		F7CF80E624A7ED1D005CF2D5 /* web3.1.2.7.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = web3.1.2.7.js; sourceTree = "<group>"; };
-		F7CF80E824A8C650005CF2D5 /* ethers.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ethers.js; sourceTree = "<group>"; };
 		F8B74603247BBA89005AB80B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F8B74604247BBADB005AB80B /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		F8B74605247BBAF1005AB80B /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -946,7 +945,6 @@
 		13B07FAE1A68108700A75B9A /* rwallet */ = {
 			isa = PBXGroup;
 			children = (
-				F7CF80E824A8C650005CF2D5 /* ethers.js */,
 				F7CF80E624A7ED1D005CF2D5 /* web3.1.2.7.js */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
@@ -1231,7 +1229,6 @@
 				DA1CFA1F7DCF4BF2B6663221 /* libRNBlur.a */,
 				B7002C49DAAA4AB4BE86FEB4 /* libRNSpringScrollView.a */,
 				FEF5D59698B44D9CBD2F88A3 /* libRNShare.a */,
-				F91A38634A714364BACD5762 /* libRNViewShot.a */,
 				8BFE01124C4041AA83A48EF6 /* libRNFS.a */,
 				D3FB31DC85AC4D4A9E984120 /* libRNFirebase.a */,
 				ED024E4523954127B9093A7A /* libRNDeviceInfo.a */,
@@ -1484,6 +1481,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = 3YDAH8ZR7C;
 						ProvisioningStyle = Automatic;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
@@ -2172,7 +2170,6 @@
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
 				F8D5F461238B92E2006CFB8D /* FontAwesome5_Brands.ttf in Resources */,
 				F8F13CDC244157D60034D167 /* GoogleService-Info.plist in Resources */,
-				F7CF80E924A8C651005CF2D5 /* ethers.js in Resources */,
 				F8D5F45D238B92E2006CFB8D /* Fontisto.ttf in Resources */,
 				F8D5F46A238B92E2006CFB8D /* EvilIcons.ttf in Resources */,
 				DAB2A624F82E41F1BF966C96 /* antfill.ttf in Resources */,
@@ -2367,9 +2364,7 @@
 				INFOPLIST_FILE = rwalletTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2415,9 +2410,7 @@
 				INFOPLIST_FILE = rwalletTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2437,7 +2430,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 14;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3YDAH8ZR7C;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Firebase",
@@ -2492,7 +2485,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 14;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3YDAH8ZR7C;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Firebase",
@@ -2582,9 +2575,7 @@
 				);
 				INFOPLIST_FILE = "rwallet-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2641,9 +2632,7 @@
 				);
 				INFOPLIST_FILE = "rwallet-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2697,9 +2686,7 @@
 				);
 				INFOPLIST_FILE = "rwallet-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2752,9 +2739,7 @@
 				);
 				INFOPLIST_FILE = "rwallet-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",

--- a/ios/rwallet.xcodeproj/project.pbxproj
+++ b/ios/rwallet.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00AD644EF595416DA8E09C2E /* libRNSpringScrollView.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B7002C49DAAA4AB4BE86FEB4 /* libRNSpringScrollView.a */; };
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
@@ -41,7 +40,6 @@
 		2D16E6881FA4F8E400B85C8A /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D16E6891FA4F8E400B85C8A /* libReact.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* rwalletTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* rwalletTests.m */; };
 		2DF0FFEE2056DD460020B375 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3EA31DF850E9000B6D8A /* libReact.a */; };
-		2F4B86582BBD4B78877B108A /* libRNViewShot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F91A38634A714364BACD5762 /* libRNViewShot.a */; };
 		35FC883137314B0EAD8D6467 /* libReactNativeFingerprintScanner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE45A9C6F39840D39B61D7BF /* libReactNativeFingerprintScanner.a */; };
 		3A4A4CA2AEC7432A8B602D08 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7E9141DC28F7435DA2CF705A /* Octicons.ttf */; };
 		3E69677E01BB40208757CAD0 /* libRNI18n-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 695867629428482FA3A90241 /* libRNI18n-tvOS.a */; };
@@ -614,13 +612,6 @@
 			remoteGlobalIDString = 2858ECD01F8B91B400610575;
 			remoteInfo = "RNVersionNumber-tvOS";
 		};
-		F8F12FC52496839D006DC605 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 591FC3AADCC743A3B2A9824A /* RNViewShot.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RNViewShot;
-		};
 		F8F12FCA2496839D006DC605 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 67A272D729CB453DAB139F6D /* RNShare.xcodeproj */;
@@ -678,7 +669,6 @@
 		51A5EDFEE4B4477EB192A66F /* libTcpSockets.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libTcpSockets.a; sourceTree = "<group>"; };
 		5266C6A7ECF444A0B9CC6A9A /* libRNRandomBytes-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNRandomBytes-tvOS.a"; sourceTree = "<group>"; };
 		582F94C93C56484E9E8F0AEE /* RNFirebase.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFirebase.xcodeproj; path = "../node_modules/@imstar15/react-native-firebase/ios/RNFirebase.xcodeproj"; sourceTree = "<group>"; };
-		591FC3AADCC743A3B2A9824A /* RNViewShot.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNViewShot.xcodeproj; path = "../node_modules/react-native-view-shot/ios/RNViewShot.xcodeproj"; sourceTree = "<group>"; };
 		5BF2C76ABE374BB8B253D35D /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		5E5E65B599004351BB86186D /* libRNSecureStorage.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSecureStorage.a; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
@@ -769,7 +759,6 @@
 		F8F13C902441559B0034D167 /* FirebaseCoreDiagnostics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FirebaseCoreDiagnostics.framework; sourceTree = "<group>"; };
 		F8F13CDA2441562D0034D167 /* rwallet.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = rwallet.entitlements; path = rwallet/rwallet.entitlements; sourceTree = "<group>"; };
 		F8F13CDB244157D60034D167 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "rwallet/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		F91A38634A714364BACD5762 /* libRNViewShot.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNViewShot.a; sourceTree = "<group>"; };
 		F97135A548F347D8814AB307 /* RNGestureHandler.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNGestureHandler.xcodeproj; path = "../node_modules/react-native-gesture-handler/ios/RNGestureHandler.xcodeproj"; sourceTree = "<group>"; };
 		FEF5D59698B44D9CBD2F88A3 /* libRNShare.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNShare.a; sourceTree = "<group>"; };
 		FF89DC8BF9AE4B249C1BA042 /* libRNSVG-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNSVG-tvOS.a"; sourceTree = "<group>"; };
@@ -833,7 +822,6 @@
 				F6FDF0F767AF4A63B18B8CCF /* libRNBlur.a in Frameworks */,
 				00AD644EF595416DA8E09C2E /* libRNSpringScrollView.a in Frameworks */,
 				CC0291990CC94EE7A06FE93F /* libRNShare.a in Frameworks */,
-				2F4B86582BBD4B78877B108A /* libRNViewShot.a in Frameworks */,
 				66A3DC1EEAA446F3A21298E2 /* libRNFS.a in Frameworks */,
 				0E51AC2823B7453AB8C01F3E /* libRNFirebase.a in Frameworks */,
 				A8DC8504C6124B108C3B1B10 /* libRNDeviceInfo.a in Frameworks */,
@@ -1060,7 +1048,6 @@
 				367E5AC68FB240C2877048F3 /* RNBlur.xcodeproj */,
 				0D0D7BCCD2914BF59ED4C643 /* RNSpringScrollView.xcodeproj */,
 				67A272D729CB453DAB139F6D /* RNShare.xcodeproj */,
-				591FC3AADCC743A3B2A9824A /* RNViewShot.xcodeproj */,
 				A2BCB74018CE401FB4197A5B /* RNFS.xcodeproj */,
 				582F94C93C56484E9E8F0AEE /* RNFirebase.xcodeproj */,
 				62D5FE51261D4141ACD95E32 /* RNDeviceInfo.xcodeproj */,
@@ -1371,14 +1358,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		F8F12FC22496839D006DC605 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8F12FC62496839D006DC605 /* libRNViewShot.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		F8F12FC72496839D006DC605 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1661,10 +1640,6 @@
 				{
 					ProductGroup = F8EC6D0324246D4D0024A7D3 /* Products */;
 					ProjectRef = 80D9FCE2F53C4818AC90A1E6 /* RNVersionNumber.xcodeproj */;
-				},
-				{
-					ProductGroup = F8F12FC22496839D006DC605 /* Products */;
-					ProjectRef = 591FC3AADCC743A3B2A9824A /* RNViewShot.xcodeproj */;
 				},
 				{
 					ProductGroup = F845070223B1A3610075F0DF /* Products */;
@@ -2162,13 +2137,6 @@
 			remoteRef = F8EC6D0924246D4D0024A7D3 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8F12FC62496839D006DC605 /* libRNViewShot.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNViewShot.a;
-			remoteRef = F8F12FC52496839D006DC605 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		F8F12FCB2496839D006DC605 /* libRNShare.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -2392,7 +2360,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2402,9 +2369,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -2444,7 +2408,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2454,9 +2417,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -2505,7 +2465,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2561,7 +2520,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2618,7 +2576,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2627,9 +2584,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -2681,7 +2635,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2690,9 +2643,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -2741,7 +2691,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2750,9 +2699,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -2800,7 +2746,6 @@
 					"$(SRCROOT)/../node_modules/@react-native-community/blur/ios",
 					"$(SRCROOT)/../node_modules/react-native-spring-scrollview/ios/SpringScrollView",
 					"$(SRCROOT)/../node_modules/react-native-share/ios",
-					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
@@ -2809,9 +2754,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",

--- a/ios/rwallet.xcodeproj/project.pbxproj
+++ b/ios/rwallet.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		2D02E4C71E0B4AEC006451C7 /* libRCTText-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E941DF850E9000B6D8A /* libRCTText-tvOS.a */; };
 		2D02E4C81E0B4AEC006451C7 /* libRCTWebSocket-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */; };
 		2D16E6881FA4F8E400B85C8A /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D16E6891FA4F8E400B85C8A /* libReact.a */; };
+		2D797650B6554EF6BC892731 /* libRNViewShot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A654CDE520E1443C9DB3D18E /* libRNViewShot.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* rwalletTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* rwalletTests.m */; };
 		2DF0FFEE2056DD460020B375 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3EA31DF850E9000B6D8A /* libReact.a */; };
 		35FC883137314B0EAD8D6467 /* libReactNativeFingerprintScanner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE45A9C6F39840D39B61D7BF /* libReactNativeFingerprintScanner.a */; };
@@ -451,6 +452,13 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = TcpSockets;
 		};
+		F85492CB2534668D00370C7E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6FE148DFBD6C405C871E70AE /* RNViewShot.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNViewShot;
+		};
 		F857CD5E246EA84D00865386 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 367E5AC68FB240C2877048F3 /* RNBlur.xcodeproj */;
@@ -679,6 +687,7 @@
 		67A272D729CB453DAB139F6D /* RNShare.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNShare.xcodeproj; path = "../node_modules/react-native-share/ios/RNShare.xcodeproj"; sourceTree = "<group>"; };
 		695867629428482FA3A90241 /* libRNI18n-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNI18n-tvOS.a"; sourceTree = "<group>"; };
 		6E61E66CB9774A2CB734FE41 /* libQRCode.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libQRCode.a; sourceTree = "<group>"; };
+		6FE148DFBD6C405C871E70AE /* RNViewShot.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNViewShot.xcodeproj; path = "../node_modules/react-native-view-shot/ios/RNViewShot.xcodeproj"; sourceTree = "<group>"; };
 		730CF1A67A584AC9B0C5A2A3 /* libRNVersionNumber.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNVersionNumber.a; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		7A6B7A45AEC34BECA0BF6C94 /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
@@ -699,6 +708,7 @@
 		9E91A35359A84B99A59F5D31 /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
 		A26F97B0F2CB4BE09A09F759 /* RNSecureStorage.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSecureStorage.xcodeproj; path = "../node_modules/rn-secure-storage/ios/RNSecureStorage.xcodeproj"; sourceTree = "<group>"; };
 		A2BCB74018CE401FB4197A5B /* RNFS.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFS.xcodeproj; path = "../node_modules/react-native-fs/RNFS.xcodeproj"; sourceTree = "<group>"; };
+		A654CDE520E1443C9DB3D18E /* libRNViewShot.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNViewShot.a; sourceTree = "<group>"; };
 		A7659CCC565444D4BF484D52 /* libRNDeviceInfo-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNDeviceInfo-tvOS.a"; sourceTree = "<group>"; };
 		AAEFACF583C4488A957B4C9E /* RNSVG.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
 		AB8C72E0A7C14325B20362FB /* Fontisto.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Fontisto.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Fontisto.ttf"; sourceTree = "<group>"; };
@@ -824,6 +834,7 @@
 				66A3DC1EEAA446F3A21298E2 /* libRNFS.a in Frameworks */,
 				0E51AC2823B7453AB8C01F3E /* libRNFirebase.a in Frameworks */,
 				A8DC8504C6124B108C3B1B10 /* libRNDeviceInfo.a in Frameworks */,
+				2D797650B6554EF6BC892731 /* libRNViewShot.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1049,6 +1060,7 @@
 				A2BCB74018CE401FB4197A5B /* RNFS.xcodeproj */,
 				582F94C93C56484E9E8F0AEE /* RNFirebase.xcodeproj */,
 				62D5FE51261D4141ACD95E32 /* RNDeviceInfo.xcodeproj */,
+				6FE148DFBD6C405C871E70AE /* RNViewShot.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1191,6 +1203,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		F85492C82534668D00370C7E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F85492CC2534668D00370C7E /* libRNViewShot.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		F857CD5A246EA84D00865386 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1233,6 +1253,7 @@
 				D3FB31DC85AC4D4A9E984120 /* libRNFirebase.a */,
 				ED024E4523954127B9093A7A /* libRNDeviceInfo.a */,
 				A7659CCC565444D4BF484D52 /* libRNDeviceInfo-tvOS.a */,
+				A654CDE520E1443C9DB3D18E /* libRNViewShot.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1481,7 +1502,6 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 3YDAH8ZR7C;
 						ProvisioningStyle = Automatic;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
@@ -1638,6 +1658,10 @@
 				{
 					ProductGroup = F8EC6D0324246D4D0024A7D3 /* Products */;
 					ProjectRef = 80D9FCE2F53C4818AC90A1E6 /* RNVersionNumber.xcodeproj */;
+				},
+				{
+					ProductGroup = F85492C82534668D00370C7E /* Products */;
+					ProjectRef = 6FE148DFBD6C405C871E70AE /* RNViewShot.xcodeproj */;
 				},
 				{
 					ProductGroup = F845070223B1A3610075F0DF /* Products */;
@@ -1972,6 +1996,13 @@
 			fileType = archive.ar;
 			path = libTcpSockets.a;
 			remoteRef = F845070523B1A3610075F0DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F85492CC2534668D00370C7E /* libRNViewShot.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNViewShot.a;
+			remoteRef = F85492CB2534668D00370C7E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		F857CD5F246EA84D00865386 /* libRNBlur.a */ = {
@@ -2360,11 +2391,15 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = rwalletTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2406,11 +2441,15 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = rwalletTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2430,7 +2469,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 14;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = 3YDAH8ZR7C;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Firebase",
@@ -2461,6 +2500,7 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = rwallet/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2485,7 +2525,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 14;
-				DEVELOPMENT_TEAM = 3YDAH8ZR7C;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Firebase",
@@ -2516,6 +2556,7 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = rwallet/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2572,10 +2613,14 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = "rwallet-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2629,10 +2674,14 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = "rwallet-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2683,10 +2732,14 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = "rwallet-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -2736,10 +2789,14 @@
 					"$(SRCROOT)/../node_modules/react-native-fs/**",
 					"$(SRCROOT)/../node_modules/@imstar15/react-native-firebase/ios/RNFirebase/**",
 					"$(SRCROOT)/../node_modules/react-native-device-info/ios/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = "rwallet-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14027,6 +14027,11 @@
       "resolved": "https://registry.npmjs.org/react-native-version-number/-/react-native-version-number-0.3.6.tgz",
       "integrity": "sha512-TdyXiK90NiwmSbmAUlUBOV6WI1QGoqtvZZzI5zQY4fKl67B3ZrZn/h+Wy/OYIKKFMfePSiyfeIs8LtHGOZ/NgA=="
     },
+    "react-native-view-shot": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npm.taobao.org/react-native-view-shot/download/react-native-view-shot-3.1.2.tgz",
+      "integrity": "sha1-jI6ExnpLyLYD5pfbvVnbybT4SCU="
+    },
     "react-native-webview": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-10.3.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2656,6 +2656,11 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-1.1.4.tgz",
       "integrity": "sha512-ecs5g1MSonDQdbPMghYkBLvJkXTOPziqVUwDUl9GDjoND+cDZDnOr+0z1IX+SZs2AdUOa8r+r8a7UyNt8MDNrw=="
     },
+    "@react-native-community/toolbar-android": {
+      "version": "0.1.0-rc.2",
+      "resolved": "https://registry.npm.taobao.org/@react-native-community/toolbar-android/download/@react-native-community/toolbar-android-0.1.0-rc.2.tgz",
+      "integrity": "sha1-hsrmVYNq+sxS1AYwYsxZg30ahkA="
+    },
     "@react-native-community/viewpager": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@react-native-community/viewpager/-/viewpager-1.1.7.tgz",
@@ -2789,7 +2794,7 @@
         "lodash": "^4.17.11",
         "pbkdf2": "^3.0.17",
         "randombytes": "^2.1.0",
-        "scrypt-shim": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+        "scrypt-shim": "github:web3-js/scrypt-shim",
         "uuid": "3.3.2",
         "web3-core": "2.0.0-alpha.1",
         "web3-core-helpers": "2.0.0-alpha.1",
@@ -3120,6 +3125,91 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        }
+      }
+    },
+    "@walletconnect/client": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/@walletconnect/client/download/@walletconnect/client-1.3.1.tgz",
+      "integrity": "sha1-W4Fg/hVhXKcBemvhsSXYheOd3xI=",
+      "requires": {
+        "@walletconnect/core": "^1.3.1",
+        "@walletconnect/iso-crypto": "^1.3.1",
+        "@walletconnect/types": "^1.3.1",
+        "@walletconnect/utils": "^1.3.1"
+      }
+    },
+    "@walletconnect/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/@walletconnect/core/download/@walletconnect/core-1.3.1.tgz",
+      "integrity": "sha1-f3xpKtTH3jdUTGEK0Nhj3dyyOxk=",
+      "requires": {
+        "@walletconnect/socket-transport": "^1.3.1",
+        "@walletconnect/types": "^1.3.1",
+        "@walletconnect/utils": "^1.3.1"
+      }
+    },
+    "@walletconnect/iso-crypto": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/@walletconnect/iso-crypto/download/@walletconnect/iso-crypto-1.3.1.tgz",
+      "integrity": "sha1-/OjRI1ogWXKN+4eo0N+sIF8pWTc=",
+      "requires": {
+        "@walletconnect/types": "^1.3.1",
+        "@walletconnect/utils": "^1.3.1",
+        "eccrypto-js": "5.2.0"
+      }
+    },
+    "@walletconnect/socket-transport": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/@walletconnect/socket-transport/download/@walletconnect/socket-transport-1.3.1.tgz",
+      "integrity": "sha1-s4VCJf2umvDYZdAC9+AyzYmuRng=",
+      "requires": {
+        "@walletconnect/types": "^1.3.1",
+        "ws": "7.3.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npm.taobao.org/ws/download/ws-7.3.0.tgz?cache=0&sync_timestamp=1593925746458&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fws%2Fdownload%2Fws-7.3.0.tgz",
+          "integrity": "sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0="
+        }
+      }
+    },
+    "@walletconnect/types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/@walletconnect/types/download/@walletconnect/types-1.3.1.tgz?cache=0&sync_timestamp=1602330308492&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40walletconnect%2Ftypes%2Fdownload%2F%40walletconnect%2Ftypes-1.3.1.tgz",
+      "integrity": "sha1-/vo9XPsuaMBDnQf30yE09pJ3WoA="
+    },
+    "@walletconnect/utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/@walletconnect/utils/download/@walletconnect/utils-1.3.1.tgz?cache=0&sync_timestamp=1602330313966&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40walletconnect%2Futils%2Fdownload%2F%40walletconnect%2Futils-1.3.1.tgz",
+      "integrity": "sha1-iEGIVtKL3Gg9U9D60qzccLXIhSg=",
+      "requires": {
+        "@walletconnect/types": "^1.3.1",
+        "detect-browser": "5.1.0",
+        "enc-utils": "2.1.0",
+        "js-sha3": "0.8.0",
+        "query-string": "6.13.5",
+        "rpc-payload-id": "1.0.0",
+        "safe-json-utils": "1.0.0",
+        "window-getters": "1.0.0",
+        "window-metadata": "1.0.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npm.taobao.org/js-sha3/download/js-sha3-0.8.0.tgz",
+          "integrity": "sha1-ubel2nOvrX3t0PjEY5VMveaBiEA="
+        },
+        "query-string": {
+          "version": "6.13.5",
+          "resolved": "https://registry.npm.taobao.org/query-string/download/query-string-6.13.5.tgz",
+          "integrity": "sha1-meleL7cCHbkKbzc/mQwMgUs4Etg=",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
         }
       }
     },
@@ -3620,7 +3710,7 @@
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/array-find-index/download/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-includes": {
@@ -3666,7 +3756,7 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/arrify/download/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "art": {
@@ -4455,7 +4545,7 @@
     },
     "camelcase-keys": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/camelcase-keys/download/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "requires": {
         "camelcase": "^4.1.0",
@@ -5040,7 +5130,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npm.taobao.org/currently-unhandled/download/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
         "array-find-index": "^1.0.1"
@@ -5120,7 +5210,7 @@
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/decamelize-keys/download/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -5129,7 +5219,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://registry.npm.taobao.org/map-obj/download/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
@@ -5307,6 +5397,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-browser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npm.taobao.org/detect-browser/download/detect-browser-5.1.0.tgz?cache=0&sync_timestamp=1592803473542&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdetect-browser%2Fdownload%2Fdetect-browser-5.1.0.tgz",
+      "integrity": "sha1-DFHGa3R62PmKaDK/MCalojp4UP8="
+    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -5434,6 +5529,60 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "eccrypto-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npm.taobao.org/eccrypto-js/download/eccrypto-js-5.2.0.tgz",
+      "integrity": "sha1-6zs26ZeNMW/t9QvkZJK7DT4kDPU=",
+      "requires": {
+        "aes-js": "3.1.2",
+        "enc-utils": "2.1.0",
+        "hash.js": "1.1.7",
+        "js-sha3": "0.8.0",
+        "randombytes": "2.1.0",
+        "secp256k1": "3.8.0"
+      },
+      "dependencies": {
+        "aes-js": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npm.taobao.org/aes-js/download/aes-js-3.1.2.tgz",
+          "integrity": "sha1-25qr3oXVyqu/wNTypERpYPYnFGo="
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.3.tgz",
+          "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npm.taobao.org/js-sha3/download/js-sha3-0.8.0.tgz",
+          "integrity": "sha1-ubel2nOvrX3t0PjEY5VMveaBiEA="
+        },
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npm.taobao.org/secp256k1/download/secp256k1-3.8.0.tgz",
+          "integrity": "sha1-KPWfSwHb7pV19WpHA0t9Ljs7NS0=",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
+          }
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5463,6 +5612,16 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "enc-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/enc-utils/download/enc-utils-2.1.0.tgz",
+      "integrity": "sha1-9sKMPUuzj7QJqTGFhIzzYfT94UI=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "is-typedarray": "1.0.0",
+        "typedarray-to-buffer": "3.1.5"
+      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -6099,35 +6258,6 @@
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-    },
-    "ethereum-input-data-decoder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ethereum-input-data-decoder/-/ethereum-input-data-decoder-0.3.1.tgz",
-      "integrity": "sha512-zl3QLiHeGG94Ru9uvBeX80ZLj62YXew9JVBUR2QiU2o+wJ9kkRdTAcLD3MJq+4guabj4U2H8s3pBlamrbRzpvA==",
-      "requires": {
-        "bn.js": "^4.11.8",
-        "buffer": "^5.2.1",
-        "ethereumjs-abi": "^0.6.7",
-        "ethers": "^4.0.27",
-        "is-buffer": "^2.0.3",
-        "meow": "^5.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        }
-      }
     },
     "ethereumjs-abi": {
       "version": "0.6.8",
@@ -6810,7 +6940,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6828,11 +6959,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6845,15 +6978,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6956,7 +7092,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6966,6 +7103,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6978,17 +7116,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7005,6 +7146,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7077,7 +7219,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7087,6 +7230,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7162,7 +7306,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7192,6 +7337,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7209,6 +7355,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7247,11 +7394,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -8041,7 +8190,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
@@ -11174,7 +11323,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/loud-rejection/download/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
         "currently-unhandled": "^0.4.1",
@@ -11221,7 +11370,7 @@
     },
     "map-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/map-obj/download/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
     },
     "map-visit": {
@@ -11278,7 +11427,7 @@
       "dependencies": {
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/load-json-file/download/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -11297,12 +11446,12 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/pify/download/pify-3.0.0.tgz?cache=0&sync_timestamp=1593529716831&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpify%2Fdownload%2Fpify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "requires": {
             "load-json-file": "^4.0.0",
@@ -11312,7 +11461,7 @@
         },
         "read-pkg-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "requires": {
             "find-up": "^2.0.0",
@@ -13136,7 +13285,7 @@
     },
     "quick-lru": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/quick-lru/download/quick-lru-1.1.0.tgz?cache=0&sync_timestamp=1591017187619&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquick-lru%2Fdownload%2Fquick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
     },
     "raf": {
@@ -13878,11 +14027,6 @@
       "resolved": "https://registry.npmjs.org/react-native-version-number/-/react-native-version-number-0.3.6.tgz",
       "integrity": "sha512-TdyXiK90NiwmSbmAUlUBOV6WI1QGoqtvZZzI5zQY4fKl67B3ZrZn/h+Wy/OYIKKFMfePSiyfeIs8LtHGOZ/NgA=="
     },
-    "react-native-view-shot": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz",
-      "integrity": "sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q=="
-    },
     "react-native-webview": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-10.3.2.tgz",
@@ -14075,7 +14219,7 @@
     },
     "redent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/redent/download/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "requires": {
         "indent-string": "^3.0.0",
@@ -14084,7 +14228,7 @@
       "dependencies": {
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://registry.npm.taobao.org/indent-string/download/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         }
       }
@@ -14370,6 +14514,35 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "rn-ethereum-input-data-decoder": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npm.taobao.org/rn-ethereum-input-data-decoder/download/rn-ethereum-input-data-decoder-0.1.1.tgz",
+      "integrity": "sha1-cR6O+KpebIJGm1R26zJz4+G3IZQ=",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "buffer": "^5.2.1",
+        "ethereumjs-abi": "^0.6.7",
+        "ethers": "^4.0.27",
+        "is-buffer": "^2.0.3",
+        "meow": "^5.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npm.taobao.org/buffer/download/buffer-5.6.0.tgz",
+          "integrity": "sha1-oxdJ3H2B2E2wir+Te2uMQDP2J4Y=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npm.taobao.org/is-buffer/download/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+        }
+      }
+    },
     "rn-placeholder": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rn-placeholder/-/rn-placeholder-3.0.0.tgz",
@@ -14486,6 +14659,11 @@
         "estree-walker": "^0.6.1"
       }
     },
+    "rpc-payload-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/rpc-payload-id/download/rpc-payload-id-1.0.0.tgz",
+      "integrity": "sha1-7NXNM/olooD/n8RdTqjjMzzLVk0="
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -14541,6 +14719,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-json-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/safe-json-utils/download/safe-json-utils-1.0.0.tgz",
+      "integrity": "sha1-ix1osTz/Ksalto5sllHPf4u1bZs="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15504,7 +15687,7 @@
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/strip-indent/download/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
     },
     "strip-json-comments": {
@@ -15878,7 +16061,7 @@
     },
     "trim-newlines": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "resolved": "https://registry.npm.taobao.org/trim-newlines/download/trim-newlines-2.0.0.tgz",
       "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
     },
     "tslib": {
@@ -16646,6 +16829,19 @@
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
         "bs58check": "<3.0.0"
+      }
+    },
+    "window-getters": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/window-getters/download/window-getters-1.0.0.tgz",
+      "integrity": "sha1-tbJkU4xMec6tAn+Zl4UCIr9tCFI="
+    },
+    "window-metadata": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/window-metadata/download/window-metadata-1.0.0.tgz",
+      "integrity": "sha1-/s4ERtsvUL4GEqIR8l/Gk5F+gjs=",
+      "requires": {
+        "window-getters": "^1.0.0"
       }
     },
     "window-or-global": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "react-native-uuid-generator": "^6.1.1",
     "react-native-vector-icons": "^6.6.0",
     "react-native-version-number": "^0.3.6",
-    "react-native-view-shot": "^3.1.2",
     "react-native-webview": "^10.3.2",
     "react-navigation": "^3.11.0",
     "react-redux": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-native-uuid-generator": "^6.1.1",
     "react-native-vector-icons": "^6.6.0",
     "react-native-version-number": "^0.3.6",
+    "react-native-view-shot": "^3.1.2",
     "react-native-webview": "^10.3.2",
     "react-navigation": "^3.11.0",
     "react-redux": "^7.1.0",

--- a/src/pages/wallet/receive.js
+++ b/src/pages/wallet/receive.js
@@ -1,13 +1,12 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import {
-  View, Text, StyleSheet, Clipboard, Platform, Image, TouchableOpacity,
+  View, Text, StyleSheet, Clipboard, Image, TouchableOpacity,
 } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import QRCode from 'react-native-qrcode-svg';
 import Share from 'react-native-share';
-import { captureRef } from 'react-native-view-shot';
 import appActions from '../../redux/app/actions';
 import { createInfoNotification } from '../../common/notification.controller';
 import common from '../../common/common';
@@ -16,7 +15,6 @@ import BasePageGereral from '../base/base.page.general';
 import { strings } from '../../common/i18n';
 import color from '../../assets/styles/color';
 import { DEVICE } from '../../common/info';
-import flex from '../../assets/styles/layout.flex';
 import references from '../../assets/references';
 
 const QRCODE_SIZE = DEVICE.screenHeight * 0.22;
@@ -101,66 +99,13 @@ class WalletReceive extends Component {
     onSharePressed = async () => {
       const { navigation } = this.props;
       const { coin } = navigation.state.params;
-
-      const uri = await captureRef(this.page, {
-        format: 'jpg',
-        quality: 0.8,
-        result: 'tmpfile',
-      });
-
-      const url = uri;
-      const title = '';
       const message = coin && coin.address;
-      const icon = '';
-      const options = Platform.select({
-        ios: {
-          activityItemSources: [
-            { // For sharing url with custom title.
-              placeholderItem: { type: 'url', content: url },
-              item: {
-                default: { type: 'url', content: url },
-              },
-              subject: {
-                default: title,
-              },
-              linkMetadata: { originalUrl: url, url, title },
-            },
-            { // For sharing text.
-              placeholderItem: { type: 'text', content: message },
-              item: {
-                default: { type: 'text', content: message },
-                message: null, // Specify no text to share via Messages app.
-              },
-              linkMetadata: { // For showing app icon on share preview.
-                title: message,
-              },
-            },
-            { // For using custom icon instead of default text icon at share preview when sharing with message.
-              placeholderItem: {
-                type: 'url',
-                content: icon,
-              },
-              item: {
-                default: {
-                  type: 'text',
-                  content: `${message} ${url}`,
-                },
-              },
-              linkMetadata: {
-                title: message,
-                icon,
-              },
-            },
-          ],
-        },
-        default: {
-          title,
-          subject: title,
-          message: `${message} ${url}`,
-        },
-      });
 
-      Share.open(options);
+      const shareOptions = {
+        message,
+        failOnCancel: false,
+      };
+      Share.open(shareOptions);
     }
 
     render() {
@@ -176,35 +121,33 @@ class WalletReceive extends Component {
       const title = `${strings('button.Receive')} ${symbolName}`;
       return (
         // react-native-view-shot a view ref with the property collapsable = false.
-        <View style={flex.flex1} collapsable={false} ref={(ref) => { this.page = ref; }}>
-          <BasePageGereral
-            collapsable={false}
-            isSafeView={false}
-            hasBottomBtn
-            bottomBtnText="button.share"
-            bottomBtnOnPress={this.onSharePressed}
-            hasLoader={false}
-            headerComponent={<Header onBackButtonPress={() => { navigation.goBack(); }} title={title} />}
-          >
-            <View style={styles.body}>
-              <View style={[styles.qrView]}>
-                <QRCode value={qrText} size={QRCODE_SIZE} />
-              </View>
-              <View style={[styles.addressContainer]}>
-                {subdomain && (
-                  <TouchableOpacity style={[styles.address]} onPress={this.onCopySubdomainPressed}>
-                    <Text style={[styles.addressText, styles.subdomainText]}>{subdomain}</Text>
-                    <Image style={styles.copyIcon} source={references.images.copyIcon} />
-                  </TouchableOpacity>
-                )}
-                <TouchableOpacity style={[styles.address, styles.addressView]} onPress={this.onCopyAddressPressed}>
-                  <Text style={styles.addressText}>{address}</Text>
-                  <Image style={styles.copyIcon} source={references.images.copyIcon} />
-                </TouchableOpacity>
-              </View>
+        <BasePageGereral
+          collapsable={false}
+          isSafeView={false}
+          hasBottomBtn
+          bottomBtnText="button.share"
+          bottomBtnOnPress={this.onSharePressed}
+          hasLoader={false}
+          headerComponent={<Header onBackButtonPress={() => { navigation.goBack(); }} title={title} />}
+        >
+          <View style={styles.body}>
+            <View style={[styles.qrView]}>
+              <QRCode value={qrText} size={QRCODE_SIZE} />
             </View>
-          </BasePageGereral>
-        </View>
+            <View style={[styles.addressContainer]}>
+              {subdomain && (
+              <TouchableOpacity style={[styles.address]} onPress={this.onCopySubdomainPressed}>
+                <Text style={[styles.addressText, styles.subdomainText]}>{subdomain}</Text>
+                <Image style={styles.copyIcon} source={references.images.copyIcon} />
+              </TouchableOpacity>
+              )}
+              <TouchableOpacity style={[styles.address, styles.addressView]} onPress={this.onCopyAddressPressed}>
+                <Text style={styles.addressText}>{address}</Text>
+                <Image style={styles.copyIcon} source={references.images.copyIcon} />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </BasePageGereral>
       );
     }
 }


### PR DESCRIPTION
经测试，目前无法支持同时分享图片+文字到一些APP上（如微信），只能分享图片、文字其中一种内容。
我看了bitpay，它是分享钱包地址文本。

因此我去掉截图和分享图片的功能，只分享钱包地址文本。

注：目前iOS平台下，不支持分享到微信。（bitpay同样也不支持）

iOS环境，bitpay分享到微信的错误提示如下，同样也会出现在rwallet。
如果需要完全支持微信分享，需要集成微信SDK。

![image](https://user-images.githubusercontent.com/16951509/95659724-8e275480-0b55-11eb-898b-67aaa32b3e9e.png)

2020.10.12更新
修改成分享截图，iOS下微信可分享截图。
