### PR TITLE
Fix install script and add hotfix file for windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 The first three steps are needed for both Android and iOS devices.
 
-1. `npm install` to install dependencies
+1. `npm install` to install dependencies. If you are using Windows, use `npm run install:windows` to install and fix the broken metro-config blacklist.js file.
 1. Create an environment variable file named `.env` in the root directory
     ```
     # Parse server configuration

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.4.0",
   "private": true,
   "scripts": {
-    "postinstall": "jetifier",
+    "postinstall": "./node_modules/.bin/rn-nodeify --hack --install && jetifier",
+    "install:windows": "npm i && copy .\\postinstall\\blacklist.js .\\node_modules\\metro-config\\src\\defaults\\blacklist.js",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "android": "react-native run-android",
     "buildandroid": "cd android && ./gradlew assembleRelease",

--- a/postinstall/blacklist.js
+++ b/postinstall/blacklist.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.!!!!!!!!!!!!
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+ "use strict";
+
+ var path = require("path"); // Don't forget to everything listed here to `package.json`
+ // modulePathIgnorePatterns.
+ 
+ var sharedBlacklist = [
+   /node_modules[\/\\]react[\/\\]dist[\/\\].*/,
+   /website\/node_modules\/.*/,
+   /heapCapture\/bundle\.js/,
+   /.*\/__tests__\/.*/
+ ];
+ 
+ function escapeRegExp(pattern) {
+   if (Object.prototype.toString.call(pattern) === "[object RegExp]") {
+     return pattern.source.replace(/\//g, path.sep);
+   } else if (typeof pattern === "string") {
+     var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&"); // convert the '/' into an escaped local file separator
+ 
+     return escaped.replace(/\//g, "\\" + path.sep);
+   } else {
+     throw new Error("Unexpected blacklist pattern: " + pattern);
+   }
+ }
+ 
+ function blacklist(additionalBlacklist) {
+   return new RegExp(
+     "(" +
+       (additionalBlacklist || [])
+         .concat(sharedBlacklist)
+         .map(escapeRegExp)
+         .join("|") +
+       ")$"
+   );
+ }
+ 
+ module.exports = blacklist;
+ 


### PR DESCRIPTION
Two small updates for running: 

- Adds nodeify to the postinstall process which happens after installing. A developer can now run `npm i` and then `npm run android` to start the app.
- Add a copy function to the metro-config blacklist file. This solves an known issue in Windows. The fixed file was published into the `/postinstall/` folder, however, only lines 14-19 have been changed. [See this blog post for more information about the error.](https://medium.com/@wasiquehaider/metro-bundler-closing-after-running-react-native-run-android-65c6db4a3335).