### PR TITLE
Removes the buttons to get to the swap screen. 

### DIFF
--- a/src/navigation/components/bottom.tab.js
+++ b/src/navigation/components/bottom.tab.js
@@ -9,7 +9,7 @@ import { strings } from '../../common/i18n';
 import screenHelper from '../../common/screenHelper';
 import color from '../../assets/styles/color';
 
-const TABCOUNT = 4; // using let since it should be dynamic based on the config of navigation. Currently it is fixed as 2
+const TABCOUNT = 3; // using let since it should be dynamic based on the config of navigation. Currently it is fixed as 2
 
 const windowWidth = Dimensions.get('window').width;
 const tabWidth = windowWidth / TABCOUNT;

--- a/src/navigation/tab.primary.js
+++ b/src/navigation/tab.primary.js
@@ -3,7 +3,6 @@ import { View, Image, StyleSheet } from 'react-native';
 import { createBottomTabNavigator } from 'react-navigation';
 import HomeStackNavigator from './stack.home';
 import MineStackNavigator from './stack.mine';
-import ExchangeStackNavigator from './stack.exchange';
 import DAppStackNavigator from './stack.dapp';
 import TabBar from './components/bottom.tab';
 import color from '../assets/styles/color';

--- a/src/navigation/tab.primary.js
+++ b/src/navigation/tab.primary.js
@@ -32,13 +32,6 @@ const PrimaryTabNavigator = createBottomTabNavigator(
         title: 'root.Wallet',
       },
     },
-    Exchange: {
-      screen: ExchangeStackNavigator,
-      path: 'exchange',
-      navigationOptions: {
-        title: 'root.Exchange',
-      },
-    },
     DApp: {
       screen: DAppStackNavigator,
       path: 'dapp',

--- a/src/pages/wallet/dashboard/wallet.carousel.page.wallet.js
+++ b/src/pages/wallet/dashboard/wallet.carousel.page.wallet.js
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
   },
   myAssetsButtonsContainer: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
     alignItems: 'center',
     marginHorizontal: 17,
   },
@@ -277,11 +277,6 @@ class WalletPage extends Component {
                 <TouchableOpacity style={styles.ButtonView} onPress={onReceivePressed}>
                   <Image source={references.images.receive} />
                   <Loc style={[styles.receiveText]} text="button.Receive" />
-                </TouchableOpacity>
-                <View style={styles.splitLine} />
-                <TouchableOpacity style={[styles.ButtonView, styles.noBorderRight, { opacity: hasSwappableCoin && !isReadOnlyWallet ? 1 : 0.5 }]} disabled={!hasSwappableCoin} onPress={onSwapPressed}>
-                  <Image source={references.images.swap} />
-                  <Loc style={[styles.swapText]} text="button.Swap" />
                 </TouchableOpacity>
               </View>
             </View>

--- a/src/pages/wallet/dashboard/wallet.carousel.page.wallet.js
+++ b/src/pages/wallet/dashboard/wallet.carousel.page.wallet.js
@@ -224,8 +224,8 @@ class WalletPage extends Component {
 
   render() {
     const {
-      walletData, onSendPressed, onReceivePressed, onSwapPressed, onAddAssetPressed, onScanQrcodePressed,
-      currencySymbol, hasSwappableCoin,
+      walletData, onSendPressed, onReceivePressed, onAddAssetPressed, onScanQrcodePressed,
+      currencySymbol,
     } = this.props;
     const { isRefreshing } = this.state;
     const {


### PR DESCRIPTION
### What it does

Removes access to the swap screen, which is accessible from two places:

1. The main tab row at the bottom. Where the new number of items is 3 and their widths are calculated based on the screen width.
2. From the Wallet "My Assets" summary box, the swap button. CSS alignment needed to be updated.

**Screen shot from Galaxy A20e**
![image](https://user-images.githubusercontent.com/766679/110799659-14ba9c00-8284-11eb-9e7d-70889ea19a03.png)

### What it is not

This does not remove the swap UI or its interaction. The UI can be used in the future with a new swap provider.

### Manual testing

Pixel 3 (emulator) and Samsung Galaxy A20e (real)

- **Tab button row:** click through the items to make sure the hitbox was correct and the spotlight (i.e. the blue line) was the correct width and placement.
- **Summary Card** tested to make sure send and receive buttons still work, and have enough spacing between them for fat fingers.

### Referenced issues

While this does not fix the issue, it is related to issues #634 and #633.