### PR TITLE
fix: lowercases addresses before making operations

### DIFF
--- a/__test__/transaction.test.js
+++ b/__test__/transaction.test.js
@@ -33,11 +33,11 @@ describe('Transaction Suite', () => {
   it('ProcessRawTransaction', async () => {
     const expected = {
       data: undefined,
-      from: '0x1c067E968bFF32a2f231BED86cc6f56f3fF49Ad0',
+      from: '0x1c067e968bff32a2f231bed86cc6f56f3ff49ad0',
       gas: 21000,
       gasPrice: { high: '1000', low: '500', medium: '800' },
       nonce: 0,
-      to: '0x1c067E968bFF32a2f231BED86cc6f56f3fF49Ad0',
+      to: '0x1c067e968bff32a2f231bed86cc6f56f3ff49ad0',
       value: 1,
     };
     const docExpected = {

--- a/src/common/transaction/rbtccoin.js
+++ b/src/common/transaction/rbtccoin.js
@@ -28,13 +28,12 @@ export const encodeContractTransfer = async (contractAddress, type, to, value) =
 export const getTransactionFees = async (type, coin, address, toAddress, value, memo) => {
   const { symbol, contractAddress } = coin;
   const rskEndpoint = type === 'Mainnet' ? MAINNET.RSK_END_POINT : TESTNET.RSK_END_POINT;
-  const networkId = type === 'Mainnet' ? MAINNET.NETWORK_VERSION : TESTNET.NETWORK_VERSION;
   const rsk3 = new Rsk3(rskEndpoint);
   const latestBlock = await rsk3.getBlock('latest');
   const { minimumGasPrice } = latestBlock;
   const miniGasPrice = new BigNumber(minimumGasPrice, 16);
-  const from = Rsk3.utils.toChecksumAddress(address, networkId);
-  const to = Rsk3.utils.toChecksumAddress(toAddress, networkId);
+  const from = address.toLowerCase();
+  const to = toAddress.toLowerCase();
 
   // Set default gas to 40000
   let gas = 40000;
@@ -60,13 +59,11 @@ export const getTransactionFees = async (type, coin, address, toAddress, value, 
 };
 
 export const createRawTransaction = async ({
-  symbol, type, sender, receiver, value, memo, gasPrice, gas, contractAddress,
+  symbol, type, sender: from, receiver: to, value, memo, gasPrice, gas, contractAddress,
 }) => {
   const rskEndpoint = type === 'Mainnet' ? MAINNET.RSK_END_POINT : TESTNET.RSK_END_POINT;
   const networkId = type === 'Mainnet' ? MAINNET.NETWORK_VERSION : TESTNET.NETWORK_VERSION;
   const rsk3 = new Rsk3(rskEndpoint);
-  const from = Rsk3.utils.toChecksumAddress(sender, networkId);
-  const to = Rsk3.utils.toChecksumAddress(receiver, networkId);
   const nonce = await rsk3.getTransactionCount(from, 'pending');
   const rawTransaction = {
     from,
@@ -97,8 +94,8 @@ export const getRawTransactionParam = ({
   const param = {
     symbol,
     type: netType,
-    sender,
-    receiver,
+    sender: sender.toLowerCase(),
+    receiver: receiver.toLowerCase(),
     value,
     data,
     gasPrice,

--- a/src/pages/wallet/transfer.js
+++ b/src/pages/wallet/transfer.js
@@ -932,7 +932,7 @@ class Transfer extends Component {
           value = balance;
         }
       }
-      let transaction = new Transaction(coin, toAddress, value, extraParams);
+      let transaction = new Transaction(coin, toAddress.toLowerCase(), value, extraParams);
       await transaction.broadcast();
       this.setState({ loading: false });
       const completedParams = {


### PR DESCRIPTION
## What it solves
By @jessgusclark 

Checksums are important for users to understand if they are sending funds/tokens to the correct network. However, they are not needed for computers.

As such, this change leaves intact the warning to the user that the recipient address is not checksummed for this network. After the user clicks to confirm, and that they understand, there is no need to check the checksum anymore. Therefore, at this step of the process, the address can be converted to lowercase and passed on.

---
Lowercases addresses that are not shown to users.
Closes #561
Closes #558