### PR TITLE
fix: fixes btc txs by providing publicKey

### DIFF
--- a/src/common/transaction/btccoin.js
+++ b/src/common/transaction/btccoin.js
@@ -54,7 +54,7 @@ export const getTransactionInputs = async ({
  * @returns {object} Transaction builder
  */
 export const buildTransaction = ({
-  inputs, fromAddress, addressType, toAddress, netType, amount, fees, publicKey,
+  inputs, fromAddress, addressType, toAddress, netType, amount, fees, privateKey,
 }) => {
   const network = netType === 'Mainnet' ? bitcoin.networks.bitcoin : bitcoin.networks.testnet;
   const cost = amount + fees;
@@ -63,6 +63,8 @@ export const buildTransaction = ({
   // Calculate redeem script
   let redeemScript = null;
   if (addressType === BtcAddressType.segwit) {
+    const buf = Buffer.from(privateKey, 'hex');
+    const { publicKey } = bitcoin.ECPair.fromPrivateKey(buf, { network });
     const p2wpkh = bitcoin.payments.p2wpkh({ pubkey: publicKey, network });
     const p2sh = bitcoin.payments.p2sh({ redeem: p2wpkh, network });
     redeemScript = p2sh.redeem.output;

--- a/src/common/transaction/index.js
+++ b/src/common/transaction/index.js
@@ -50,7 +50,7 @@ export default class Transaction {
     console.log('Transaction.processTransaction start');
     let result = null;
     const {
-      symbol, privateKey, netType, sender, receiver, value, data, memo, gasFee, contractAddress, addressType, publicKey,
+      symbol, privateKey, netType, sender, receiver, value, data, memo, gasFee, contractAddress, addressType,
     } = this;
     try {
       if (symbol === 'BTC') {
@@ -67,7 +67,7 @@ export default class Transaction {
           netType,
           amount,
           fees,
-          publicKey,
+          privateKey,
         });
         result = btc.signTransaction({
           transactionBuilder, inputs, privateKey, netType, addressType,

--- a/src/common/wallet/btccoin.js
+++ b/src/common/wallet/btccoin.js
@@ -27,7 +27,7 @@ export default class Coin {
     this.path = `m/44'/${this.coinType}'/${this.account}'/0/0`;
   }
 
-  deriveSegwit= (root, network) => {
+  deriveSegwit = (root, network) => {
     const path = `m/84'/${this.coinType}'/${this.account}'/0/0`;
     const keyPair = root.derivePath(path);
     const { address } = payments.p2wpkh({ pubkey: keyPair.publicKey, network });
@@ -119,9 +119,9 @@ export default class Coin {
       address, chain, type, symbol,
     } = this;
     return address === json.address
-    && chain === json.chain
-    && type === json.type
-    && symbol === json.symbol;
+      && chain === json.chain
+      && type === json.type
+      && symbol === json.symbol;
   }
 
   /**


### PR DESCRIPTION
## What is does?

Gets the `publicKey` from the `privateKey` on `transaction/btccoin.js`.
`publicKey` was missing and so was throwing an error with the message `"Not enough data"` when wanted to send btc transactions.