### PR TITLE
Fix issue to return to setup after viewing terms of use

### DIFF
--- a/src/pages/start/terms.js
+++ b/src/pages/start/terms.js
@@ -98,7 +98,7 @@ class TermsPage extends Component {
           title={strings('page.start.terms.termsOfUse')}
           url={config.termsUrl[language]}
           visible={isTermsWebViewVisible}
-          onBackButtonPress={() => { this.setState({ isTermsWebViewVisible: false }); }}
+          onCloseButtonPress={() => { this.setState({ isTermsWebViewVisible: false }); }}
         />
       </SafeAreaView>
     );


### PR DESCRIPTION
## What it fixes

Allows the user to click the back button from the Terms of Use page when initially launching the app.

## Reasoning

- The property `onBackButtonPress()` is an internal function of the WebViewModal component. Instead, use the `onCloseButtonPress()` method that is accessible from the props.
- The internal `onBack...` method checks if the web component can go back, and if so, it takes the user back a page in the web browser. Perhaps they clicked on the privacy policy and now want to go back to the TOS page.
- When the user clicks on the 'x' button, it fires the `onClose...` function, which is the expected behavior.

## To test

- Uninstall the app to clear the RN storage
- Install, on the tos page, click to "View complete Terms of Use"
- Click Close
- Click "View..." again,
- Click on a link, such as "Privacy Policy", click back button
