### PR TITLE
refactor: removes unused call to createRawTransaction endpoint

### DIFF
--- a/src/common/parse.js
+++ b/src/common/parse.js
@@ -186,31 +186,6 @@ class ParseHelper {
   }
 
   /**
-   *
-   * @param {object} param
-   * @param {string} param.symbol Symbol of token
-   * @param {string} param.type type of blockchain, Mainnet or Testnet
-   * @param {string} param.sender from address
-   * @param {string} param.receiver to address
-   * @param {string} param.value amount of token to send
-   * @param {string} param.data data field
-   */
-  static createRawTransaction({
-    symbol, type, sender, receiver, value, data, preference,
-  }) {
-    console.log(`ParseHelper::createRawTransaction is called, symbol: ${symbol}, type: ${type}, sender: ${sender}, receiver: ${receiver}, value: ${value}, data: ${data}, preference: ${preference}`);
-    return Parse.Cloud.run('createRawTransaction', {
-      symbol, type, sender, receiver, value, data, preference,
-    }).then((res) => {
-      console.log(`ParseHelper::createRawTransaction received, res: ${JSON.stringify(res)}`);
-      return Promise.resolve(res);
-    }, (err) => {
-      console.log(err);
-      return Promise.reject(err);
-    });
-  }
-
-  /**
    * Send a raw transaction to server
    * @param {*} name Blockchain name, e.g. Bitcoin or Rootstock
    * @param {*} hash 0xf8692...dead0a,

--- a/src/redux/app/actions.js
+++ b/src/redux/app/actions.js
@@ -14,8 +14,6 @@ const actions = {
   GET_SERVER_INFO_RESULT: 'GET_SERVER_INFO_RESULT',
   GET_TRANSACTIONS: 'GET_TRANSACTIONS',
   GET_TRANSACTIONS_RESULT: 'GET_TRANSACTIONS_RESULT',
-  CREATE_RAW_TRANSATION: 'CREATE_RAW_TRANSATION',
-  CREATE_RAW_TRANSATION_RESULT: 'CREATE_RAW_TRANSATION_RESULT',
   SET_ERROR: 'SET_ERROR',
   SET_APPLICATION: 'SET_APPLICATION',
   SET_SETTINGS: 'SET_SETTINGS',
@@ -107,15 +105,6 @@ const actions = {
       symbol, type, address, page,
     },
   }),
-  createRawTransaction: (symbol, type, sender, receiver, value, data) => {
-    console.log('actions::createRawTransaction is called.');
-    return {
-      type: actions.CREATE_RAW_TRANSATION,
-      payload: {
-        symbol, type, sender, receiver, value, data,
-      },
-    };
-  },
   setSingleSettings: (key, value) => ({
     type: actions.SET_SINGLE_SETTINGS,
     key,

--- a/src/redux/app/reducer.js
+++ b/src/redux/app/reducer.js
@@ -67,12 +67,6 @@ export default function appReducer(state = initState, action) {
       return state.set('serverVersion', serverVersion)
         .set('updateVersionInfo', updateVersionInfo);
     }
-    case actions.CREATE_RAW_TRANSATION_RESULT:
-    {
-      const result = action.value;
-      const newstate = state.set('rawTransaction', result);
-      return newstate;
-    }
     case actions.SET_ERROR:
       return state.set('error', action.value);
     case actions.ADD_NOTIFICATION:

--- a/src/redux/app/saga.js
+++ b/src/redux/app/saga.js
@@ -209,22 +209,6 @@ function* reloginRequest() {
   yield put(actions.login(true));
 }
 
-function* createRawTransaction(action) {
-  const { payload } = action;
-  console.log('saga::createRawTransaction is triggered, payload: ', payload); // This is undefined
-  try {
-    const response = yield call(ParseHelper.createRawTransaction, payload);
-    console.log('saga::createRawTransaction got response, response: ', response);
-    yield put({
-      type: actions.CREATE_RAW_TRANSATION_RESULT,
-      value: response,
-    });
-  } catch (err) {
-    console.log(err);
-    // TODO: need to add notification here if failed
-  }
-}
-
 function* setSingleSettingsRequest(action) {
   const { key, value } = action;
   console.log('saga::setSingleSettingsRequest is triggered, key: ', key, ', value:', value);
@@ -380,7 +364,7 @@ function createFcmChannel() {
   return eventChannel((emitter) => {
     // the subscriber must return an unsubscribe function
     // this will be invoked when the saga calls `channel.close` method
-    const unsubscribeHandler = () => {};
+    const unsubscribeHandler = () => { };
 
     fcmHelper.startListen((notification, fcmType) => {
       emitter(actions.receiveNotification(notification, fcmType));
@@ -516,7 +500,6 @@ export default function* () {
     takeEvery(actions.INIT_FROM_STORAGE, initFromStorageRequest),
     takeEvery(actions.LOGIN, loginRequest),
     takeEvery(actions.RELOGIN, reloginRequest),
-    takeEvery(actions.CREATE_RAW_TRANSATION, createRawTransaction),
     takeEvery(actions.SET_SINGLE_SETTINGS, setSingleSettingsRequest),
     takeEvery(actions.UPDATE_USER, updateUserRequest),
     takeEvery(actions.CHANGE_LANGUAGE, changeLanguageRequest),


### PR DESCRIPTION
Removes `createRawTransaction` call to the server. That request is not being used anymore in the app.