### PR TITLE
Fix RNS domain resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -889,6 +889,29 @@
         "react-native-iphone-x-helper": "^1.0.3"
       }
     },
+    "@ensdomains/address-encoder": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@ensdomains/address-encoder/-/address-encoder-0.2.6.tgz",
+      "integrity": "sha512-b0jtq3vx1xxUJRwS9zJMy5SVtH1ixIS18gHm3tFyBR1ehsk/lK80nCoV1lJi0KXgQ/2RD+/KYoWlW5CNZG7AAw==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "blakejs": "^1.1.0",
+        "bn.js": "^4.11.8",
+        "bs58": "^4.0.1",
+        "crypto-addr-codec": "^0.1.7",
+        "js-sha512": "^0.8.0",
+        "nano-base32": "^1.0.1",
+        "ripemd160": "^2.0.2",
+        "sha3": "^2.1.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
     "@imstar15/react-native-firebase": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@imstar15/react-native-firebase/-/react-native-firebase-5.2.6.tgz",
@@ -1447,6 +1470,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
+    "@rsksmart/rns-resolver.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rns-resolver.js/-/rns-resolver.js-1.0.0.tgz",
+      "integrity": "sha512-7jK5gpIgrShWBg1/FiznmE1eCbWKGg00B44YhrcZj0AdBLWk/WJpFN0H4jU9l4+iiAS54IMnevUTrfP8cpNrFw==",
+      "requires": {
+        "@ensdomains/address-encoder": "^0.2.6",
+        "crypto-addr-codec": "^0.1.7",
+        "eth-ens-namehash": "^2.0.8"
+      }
     },
     "@rsksmart/rsk3": {
       "version": "0.3.4",
@@ -3853,6 +3886,27 @@
         }
       }
     },
+    "crypto-addr-codec": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
+      "integrity": "sha512-X4hzfBzNhy4mAc3UpiXEC/L0jo5E8wAa9unsnA8nNXYzXjCcGk83hfC5avJWCSGT8V91xMnAS9AKMHmjw5+XCg==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "big-integer": "1.6.36",
+        "blakejs": "^1.1.0",
+        "bs58": "^4.0.1",
+        "ripemd160-min": "0.0.6",
+        "safe-buffer": "^5.2.0",
+        "sha3": "^2.1.1"
+      },
+      "dependencies": {
+        "big-integer": {
+          "version": "1.6.36",
+          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+          "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+        }
+      }
+    },
     "crypto-js": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
@@ -5364,6 +5418,15 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      }
+    },
     "eth-lib": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
@@ -6719,6 +6782,21 @@
       "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {
@@ -8098,6 +8176,11 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
       "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+    },
+    "js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -11200,6 +11283,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
+    "nano-base32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
+      "integrity": "sha1-ulSMh578+5DaHE2eCX20pGySVe8="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -14127,6 +14215,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "ripemd160-min": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+      "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A=="
+    },
     "rlp": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
@@ -14582,6 +14675,25 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "requires": {
+        "buffer": "6.0.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/slider": "^1.1.4",
     "@react-native-community/toolbar-android": "^0.1.0-rc.2",
+    "@rsksmart/rns-resolver.js": "^1.0.0",
     "@rsksmart/rsk3": "^0.3.2",
     "@tradle/react-native-http": "^2.0.1",
     "@walletconnect/client": "^1.2.1",

--- a/src/common/parse.js
+++ b/src/common/parse.js
@@ -419,10 +419,6 @@ class ParseHelper {
     return Parse.Cloud.run('isSubdomainAvailable', params);
   }
 
-  static async querySubdomain(domain, type) {
-    return Parse.Cloud.run('querySubdomain', { domain, type });
-  }
-
   static async fetchRegisteringRnsSubdomains(records) {
     const addresses = _.map(records, (record) => record.address);
     const subdomains = _.map(records, 'subdomain');

--- a/src/pages/wallet/rns/domainToAddress.js
+++ b/src/pages/wallet/rns/domainToAddress.js
@@ -8,10 +8,8 @@ import Resolver from '@rsksmart/rns-resolver.js';
  * @param {type} constant: Mainnet or Testnet
  */
 export const domainToAddress = (domain, symbol, type) => {
-  console.log('getting address!!!! 00', domain, symbol, type);
   // eslint-disable-next-line new-cap
   const resolver = type === 'Mainnet' ? new Resolver.forRskMainnet() : new Resolver.forRskTestnet();
-  const chainId = symbol === 'BTC' ? '0' : null;
-  console.log('chainId', chainId);
+  const chainId = symbol === 'BTC' ? 0 : null;
   return resolver.addr(domain, chainId);
 };

--- a/src/pages/wallet/rns/domainToAddress.js
+++ b/src/pages/wallet/rns/domainToAddress.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/prefer-default-export */
+import Resolver from '@rsksmart/rns-resolver.js';
+
+/**
+ * Convert a RSK domain to address if available
+ * @param {string} domain string Domain to be resolved
+ * @param {string} symbol chainId to get address for
+ * @param {type} constant: Mainnet or Testnet
+ */
+export const domainToAddress = (domain, symbol, type) => {
+  console.log('getting address!!!! 00', domain, symbol, type);
+  // eslint-disable-next-line new-cap
+  const resolver = type === 'Mainnet' ? new Resolver.forRskMainnet() : new Resolver.forRskTestnet();
+  const chainId = symbol === 'BTC' ? '0' : null;
+  console.log('chainId', chainId);
+  return resolver.addr(domain, chainId);
+};


### PR DESCRIPTION
Check .rsk domains by using the [RNS Resolver JS](https://github.com/rsksmart/rns-resolver.js) package, rather than connecting to the server to get the resolved address. Works with RSK address on Testnet and Mainnet and BTC on Mainnet.

**Note**: with the RNS Manager, there is no way to set the BTC address to a testnet address [See this issue](https://github.com/rnsdomains/rns-manager-react/issues/401). Therefore, when sending tBTC, it will always throw the error "Address is not valid". BTC on Mainnet works correct.

## Fixes: 
- Previous resolver would only allow `*.wallet.rsk` addresses. This fix allows any .rsk address.
- Single sources search for address using `domainToAddress` file. 
- When an address is not found, or the package throws an error, show 'can't find domain' message to user rather than unhelpful 'Internal Error, contact support'. 

## To Test:

Register a domain using the [Testnet RNS Manager](https://testnet.manager.rns.rifos.org/) and set the RSK and BTC addresses. Or use the domains below:

#### Testnet:

* `public.jesse.rsk` uses the Public Resolver
* `multi.jesse.rsk` uses the MultiChain Resolver
* `rwallet.jesse.rsk` uses the Definitive Resolver

All 3 will resolve to: `0x3Dd03d7d6c3137f1Eb7582Ba5957b8A2e26f304A`

* `jesse.wallet.rsk` uses the public resolver and will resolve to `0x860e0414EbCAc36ebF98d788349C9F00F3C4f353`

#### Mainnet:

This is the only one, I think. 

* `jesse.rsk` uses the Definitive resolver and has BTC and RSK addresses set. 

### Testing:

- Send transactions to the RSK domains above as well as addresses. 
- Add a read-only wallet using the RSK domain. For adding, it will resolve the RSK address and get the coins. It will not get the BTC address associated with the account. 

