### PR TITLE
Improve dapp browser

### DIFF
--- a/src/common/common.js
+++ b/src/common/common.js
@@ -621,7 +621,7 @@ const common = {
   },
 
   /**
-   * Chcke address is contract addrsss
+   * Check address is contract addrsss
    * @param {*} address need check address
    * @param {*} chainId chain id
    */
@@ -629,8 +629,7 @@ const common = {
     return new Promise((resolve, reject) => {
       const rskEndpoint = chainId === TESTNET.NETWORK_VERSION ? TESTNET.RSK_END_POINT : MAINNET.RSK_END_POINT;
       const rsk3 = new Rsk3(rskEndpoint);
-      const checksumAddress = Rsk3.utils.toChecksumAddress(address, chainId);
-      rsk3.getCode(checksumAddress).then((code) => {
+      rsk3.getCode(address).then((code) => {
         if (code !== '0x00') {
           resolve(true);
         } else {

--- a/src/components/common/modal/wallet.selection.modal.js
+++ b/src/components/common/modal/wallet.selection.modal.js
@@ -145,6 +145,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontFamily: fontFamily.AvenirBook,
     marginLeft: 11,
+    width: '100%',
   },
   tokenText: {
     fontFamily: fontFamily.AvenirRoman,
@@ -243,7 +244,7 @@ class WalletSelection extends PureComponent {
   getWalletItem = ({ item }) => {
     const { selectedWallet } = this.state;
     const { address: selectedAddress } = selectedWallet;
-    const { address, network } = item;
+    const { address, network, name } = item;
     return (
       <TouchableOpacity activeOpacity={1} onPress={() => { this.setState({ selectedWallet: item }); }}>
         <View style={styles.selection}>
@@ -251,7 +252,10 @@ class WalletSelection extends PureComponent {
             <View style={[network === 'Mainnet' ? styles.mainnet : styles.testnet]}>
               {network && <Text style={styles.network}>{strings(`networkType.${_.toLower(network)}`)}</Text>}
             </View>
-            <Text style={styles.address}>{common.ellipsisAddress(address, 6)}</Text>
+            <View>
+              <Text style={styles.address}>{name}</Text>
+              <Text style={styles.address}>{common.ellipsisAddress(address, 6)}</Text>
+            </View>
           </View>
           <View style={styles.circle}>
             <View style={selectedAddress === address ? styles.isSelected : {}} />

--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -479,7 +479,8 @@ class DAppBrowser extends Component {
   popupMessageModal = async (payload) => {
     const dappUrl = this.getDappUrl();
     const { id, params } = payload;
-    const message = this.rsk3.utils.hexToAscii(params[0]);
+    const message = params[0].startsWith('0x') ? this.rsk3.utils.hexToAscii(params[0]) : params[0];
+
     this.setState({
       modalView: (
         <MessageModal
@@ -597,7 +598,7 @@ class DAppBrowser extends Component {
       value,
     };
     const networkId = network === 'Mainnet' ? MAINNET.NETWORK_VERSION : TESTNET.NETWORK_VERSION;
-    const toAddress = Rsk3.utils.toChecksumAddress(to, networkId);
+    const toAddress = to.toLowerCase();
 
     const isContractAddress = await common.isContractAddress(toAddress, networkId);
 

--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -328,7 +328,7 @@ class DAppBrowser extends Component {
             }
 
             // ensure window.ethereum.send and window.ethereum.sendAsync are not undefined
-            setInterval(() => {
+            setTimeout(() => {
               if (!window.ethereum.send) {
                 window.ethereum.send = sendAsync;
               }
@@ -336,7 +336,12 @@ class DAppBrowser extends Component {
                 window.ethereum.sendAsync = sendAsync;
               }
               if (!window.ethereum.request) {
-                window.ethereum.request = (payload) => sendAsync(payload).then(response => response.result)
+                window.ethereum.request = (payload) =>
+                  new Promise((resolve, reject) =>
+                    sendAsync(payload).then(response =>
+                      response.result
+                        ? resolve(response.result)
+                        : reject(new Error(response.message || 'provider error'))));
               }
             }, 1000)
           }

--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -336,7 +336,7 @@ class DAppBrowser extends Component {
                 window.ethereum.sendAsync = sendAsync;
               }
               if (!window.ethereum.request) {
-                window.ethereum.request = sendAsync;
+                window.ethereum.request = (payload) => sendAsync(payload).then(response => response.result)
               }
             }, 1000)
           }

--- a/src/pages/dapp/browser.js
+++ b/src/pages/dapp/browser.js
@@ -222,6 +222,7 @@ class DAppBrowser extends Component {
             window.ethereum.selectedAddress = '${address}';
             window.address = '${address}';
             window.ethereum.networkVersion = '${this.networkVersion}';
+            window.ethereum.isRWallet = true;
             window.web3 = web3;
 
             // Adapt web3 old version (new web3 version move toDecimal and toBigNumber to utils class).

--- a/src/pages/wallet/wallet.connect/modal/message.js
+++ b/src/pages/wallet/wallet.connect/modal/message.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import {
+  View, Text, ScrollView, StyleSheet,
+} from 'react-native';
 import PropTypes from 'prop-types';
 
 import { strings } from '../../../../common/i18n';
@@ -25,8 +27,12 @@ const styles = StyleSheet.create({
     color: color.dustyGray,
     fontSize: 15,
     fontFamily: fontFamily.AvenirBook,
-    width: '60%',
     textAlign: 'right',
+  },
+  scroll: {
+    width: '60%',
+    padding: 5,
+    maxHeight: 200,
   },
 });
 
@@ -41,7 +47,9 @@ export default function MessageModal({
         <>
           <View style={styles.line}>
             <Text style={styles.lineTitle}>{strings('page.wallet.walletconnect.message')}</Text>
-            <Text style={styles.lineValue}>{message}</Text>
+            <ScrollView style={styles.scroll}>
+              <Text style={styles.lineValue}>{message}</Text>
+            </ScrollView>
           </View>
         </>
         )}


### PR DESCRIPTION
Improvements to the rWallet Dapp Browser.

- Removes internal checksums. Case: dapp submits a lowercase address and wallet was converting to checksummed version for some reason. 
- Allows signing of strings, not just hex values.
- Show wallet name above address when choosing which account to use.
- Adds isRWallet flag to the web3 provider. Resolves #643 
- Adds scrollable view when signing messages if the message is too large. Will be used in the future, when creating presentations from the RIF Id Manager. Resolves #635
- Fixes response type when sending `provider.request` from a dapp.

## sendAsync !== request

Let's talk about [this code](https://github.com/rsksmart/rwallet/pull/653/files#diff-0880122ef7a357df624e92aeeb17f19fca9e62f7699f82fe01140885e9b6fb8eR339-R344):

```
window.ethereum.request = (payload) =>
  new Promise((resolve, reject) =>
    sendAsync(payload).then(response =>
      response.result
        ? resolve(response.result)
        : reject(new Error(response.message || 'provider error'))));
```

It replaces:

```
window.ethereum.request = sendAsync;
```

`send` and `sendAsync` both return a JSON RPC object which was handled correctly. However `request` should return just the value. With the previous code, it returned the RPC object, which was causing errors with newer web3 connectors, such as rlogin.

According to [EIP 1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#sendasync-deprecated) `send` and `sendAsync` are deprecated in favor of `request`.

This also checks if the `response.result`  is undefined, if it is, it rejects the promise. This is a hacky way to handle the error described in #655.

## To Test

I have been using the [rLogin Sample App](https://basic-sample.rlogin.identity.rifos.org/) for testing basic functionality.