### PR TITLE
Disable Back button for biometrics and passcode modal.

### DIFF
--- a/src/navigation/component.js
+++ b/src/navigation/component.js
@@ -116,23 +116,6 @@ class RootComponent extends Component {
     initLiveQueryBlockHeights();
   }
 
-  onRequestClose = () => {
-    const {
-      passcodeFallback, closePasscodeModal, showPasscode, hideFingerprintModal, isShowFingerprintModal, fingerprintFallback,
-    } = this.props;
-    if (showPasscode) {
-      if (passcodeFallback) {
-        passcodeFallback();
-      }
-      closePasscodeModal();
-    } else if (isShowFingerprintModal) {
-      if (fingerprintFallback) {
-        fingerprintFallback();
-      }
-      hideFingerprintModal();
-    }
-  }
-
   render() {
     const {
       showNotification, notification, removeNotification, notificationCloseCallback,
@@ -158,7 +141,7 @@ class RootComponent extends Component {
             <Modal
               animationType="fade"
               transparent
-              onRequestClose={this.onRequestClose}
+              onRequestClose={() => false}
             >
               <BlurView
                 blurType="dark"


### PR DESCRIPTION
This PR removes the hardware back button functionality to close the Fingerprint and Passcode modal. 

With other parts of the app, such as the Dapp Browser, disabling the back button can be done with the [BackHandler](https://reactnative.dev/docs/backhandler). However, since this a modal, and is visible, `BackHandler` events will not fire. See the first warning in the BackHandler link above. As such, the [onRequestClose](https://reactnative.dev/docs/modal#onrequestclose) event will fire when the Back Button is pressed.

In the previous code, if the user clicked the back button, it fired the `onRequestClose` event, which in the end, would hide the modal's contents, closing the modal. See removed lines 127 and 132.

The biometrics component already had the functionality to fallback to a passcode. Therefore, the required function `onRequestClose` should always return `false`.

## Tested on:

- Samsung A20e (passcode)
- Emulator Pixel 3 (emulated fingerprint)

## How to test:

- Start the app with a passcode, click back. Nothing should happen. Enter passcode
- Enable Fingerprint, close the app, start the app, click back. Nothing should happen. Enter fingerprint.

**iOS Note:** I am unable to test iOS. Please make sure you can log in with existing login options.
