### PR TITLE
Change claro to limpiar.

### DIFF
--- a/src/common/translations/es.json
+++ b/src/common/translations/es.json
@@ -392,7 +392,7 @@
     "CONFIRM": "CONFIRMAR",
     "retry": "Procesar de nuevo",
     "IMPORT": "IMPORTAR",
-    "Clear": "Claro",
+    "Clear": "Limpiar",
     "startOver": "COMENZAR DE NUEVO",
     "Copy": "Copiar",
     "confirm": "Confirmar",


### PR DESCRIPTION
I did a search of the code to make sure that this string isn't used anywhere else. It is only used once, on the verify screen below confirm: https://github.com/rsksmart/rwallet/blob/master/src/pages/wallet/verify.phrase.js#L323