### PR TITLE
Fix Spanish language text

### DIFF
--- a/src/common/translations/es.json
+++ b/src/common/translations/es.json
@@ -346,7 +346,7 @@
         "title": "Configurar billetera",
         "walletContains": {
           "one": "Esta billetera contiene 1 activos",
-          "other": "Esta billetera contiene {count} activos"
+          "other": "Esta billetera contiene {{count}} activos"
         },
         "wallets": "billeteras",
         "security": "Seguridad",


### PR DESCRIPTION
Add curly brackets to count in Spanish string. Checked other languages and all of them have five instances of `{{count}}`.

![image](https://user-images.githubusercontent.com/766679/114555228-2a9af280-9c70-11eb-84f4-a09a7ca6b060.png)
