### PR TITLE
feat: locks passcode screen on too many wrong consecutive attempts

### DIFF
--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -9,6 +9,8 @@ const SECURE_KEY_PASSCODE = 'PASSCODE';
 const SECURE_KEY_PHRASE_PREFIX = 'PHRASE_';
 const SECURE_KEY_PRIVATE_KEY_PREFIX = 'PRIVATE_KEY_';
 const SECURE_USER_PASSWORD = 'USER_PASSWORD';
+const SECURE_LAST_WRONG_PASSCODE_TIMESTAMP = 'LAST_WRONG_PASSCODE_TIMESTAMP';
+const SECURE_WRONG_PASSCODE_COUNTER = 'WRONG_PASSCODE_COUNTER';
 
 const KEY_DAPPS = 'DAPPS';
 const KEY_DAPP_TYPES = 'DAPPTYPES';
@@ -62,12 +64,12 @@ class RNStorage {
   async load(params) {
     return this.instance.load(params)
       .catch((err) => {
-      // any exception including data not found goes to catch()
+        // any exception including data not found goes to catch()
         switch (err.name) {
           case 'NotFoundError':
             return null;
           case 'ExpiredError':
-          // TODO: figure out what we actually want to do to this case
+            // TODO: figure out what we actually want to do to this case
             return null;
           default:
             return null;
@@ -86,7 +88,6 @@ class RNStorage {
       key, id: id || undefined, autoSync: false, syncInBackground: false,
     });
   }
-
 
   /**
    *
@@ -391,6 +392,14 @@ class RNStorage {
   setUserPassword = (password) => RNStorage.secureSet(SECURE_USER_PASSWORD, password)
 
   getUserPassword = () => RNStorage.secureGet(SECURE_USER_PASSWORD)
+
+  setLastPasscodeAttempt = (timestamp) => RNStorage.secureSet(SECURE_LAST_WRONG_PASSCODE_TIMESTAMP, timestamp);
+
+  getLastPasscodeAttempt = () => RNStorage.secureGet(SECURE_LAST_WRONG_PASSCODE_TIMESTAMP);
+
+  setWrongPasscodeCounter = (count) => RNStorage.secureSet(SECURE_WRONG_PASSCODE_COUNTER, count);
+
+  getWrongPasscodeCounter = () => RNStorage.secureGet(SECURE_WRONG_PASSCODE_COUNTER);
 }
 
 export default new RNStorage();

--- a/src/common/translations/en.json
+++ b/src/common/translations/en.json
@@ -506,7 +506,8 @@
     },
     "verifyPasscode": {
       "type": "Type your passcode",
-      "incorrect": "Passcode is incorrect"
+      "incorrect": "Passcode is incorrect",
+      "tryAgainIn": "You can try again in"
     },
     "touchSensor": {
       "usePasscode": "Use passcode",

--- a/src/common/translations/es.json
+++ b/src/common/translations/es.json
@@ -509,7 +509,8 @@
     },
     "verifyPasscode": {
       "type": "Escribe tu contraseña",
-      "incorrect": "La contraseña es incorrecta"
+      "incorrect": "La contraseña es incorrecta",
+      "tryAgainIn": "Puede intentar de nuevo en"
     },
     "touchSensor": {
       "usePasscode": "Usar contraseña",

--- a/src/common/translations/ja.json
+++ b/src/common/translations/ja.json
@@ -506,7 +506,8 @@
     },
     "verifyPasscode": {
       "type": "パスコードを入力してください",
-      "incorrect": "パスコードが正しくありません"
+      "incorrect": "パスコードが正しくありません",
+      "tryAgainIn": "で再試行できます"
     },
     "touchSensor": {
       "usePasscode": "パスコードを使用",

--- a/src/common/translations/ko.json
+++ b/src/common/translations/ko.json
@@ -512,7 +512,8 @@
     },
     "verifyPasscode": {
       "type": "패스코드 입력",
-      "incorrect": "패스코드가 잘못되었습니다"
+      "incorrect": "패스코드가 잘못되었습니다",
+      "tryAgainIn": "다음에서 다시 시도 할 수 있습니다."
     },
     "touchSensor": {
       "usePasscode": "패스코드 사용",

--- a/src/common/translations/pt-BR.json
+++ b/src/common/translations/pt-BR.json
@@ -522,7 +522,8 @@
     },
     "verifyPasscode": {
       "type": "Digite seu PIN",
-      "incorrect": "O PIN está incorreto"
+      "incorrect": "O PIN está incorreto",
+      "tryAgainIn": "Você pode tentar novamente em"
     },
     "touchSensor": {
       "usePasscode": "Usar PIN",

--- a/src/common/translations/pt.json
+++ b/src/common/translations/pt.json
@@ -522,7 +522,8 @@
     },
     "verifyPasscode": {
       "type": "Digite seu PIN",
-      "incorrect": "O PIN está incorreto"
+      "incorrect": "O PIN está incorreto",
+      "tryAgainIn": "Você pode tentar novamente em"
     },
     "touchSensor": {
       "usePasscode": "Usar PIN",

--- a/src/common/translations/ru.json
+++ b/src/common/translations/ru.json
@@ -506,7 +506,8 @@
     },
     "verifyPasscode": {
       "type": "Введите свой пароль",
-      "incorrect": "Неверный пароль"
+      "incorrect": "Неверный пароль",
+      "tryAgainIn": "Вы можете попробовать еще раз через"
     },
     "touchSensor": {
       "usePasscode": "Используйте пароль",

--- a/src/common/translations/zh.json
+++ b/src/common/translations/zh.json
@@ -513,7 +513,8 @@
     },
     "verifyPasscode": {
       "type": "输入密码",
-      "incorrect": "密码不正确"
+      "incorrect": "密码不正确",
+      "tryAgainIn": "您可以在以下位置重试"
     },
     "touchSensor": {
       "usePasscode": "使用密码验证",

--- a/src/components/common/passcode/passcode.modal.base.js
+++ b/src/components/common/passcode/passcode.modal.base.js
@@ -159,7 +159,7 @@ class PasscodeModalBase extends PureComponent {
       input: '', title: 'You can try again in', locked: true, timer: WAITING_TIME_MS,
     });
 
-    setInterval(() => this.setState((prevState) => ({ timer: prevState.timer - 1000 })), 1000);
+    const interval = setInterval(() => this.setState((prevState) => ({ timer: prevState.timer - 1000 })), 1000);
 
     setTimeout(() => {
       this.setState({
@@ -167,6 +167,7 @@ class PasscodeModalBase extends PureComponent {
         locked: false,
         timer: 0,
       });
+      clearInterval(interval);
     }, WAITING_TIME_MS);
   }
 

--- a/src/components/common/passcode/passcode.modal.base.js
+++ b/src/components/common/passcode/passcode.modal.base.js
@@ -10,6 +10,7 @@ import fontFamily from '../../../assets/styles/font.family';
 import Loc from '../misc/loc';
 import references from '../../../assets/references';
 import storage from '../../../common/storage';
+import Loader from '../misc/loader';
 
 const buttonSize = 75;
 const dotSize = 13;
@@ -119,6 +120,7 @@ class PasscodeModalBase extends PureComponent {
       input: '',
       locked: false,
       timer: 0,
+      isLoading: true,
     };
     this.onPressButton = this.onPressButton.bind(this);
     this.onDeletePressed = this.onDeletePressed.bind(this);
@@ -128,6 +130,7 @@ class PasscodeModalBase extends PureComponent {
     this.wrongAttemptsCounter = parseInt(await storage.getWrongPasscodeCounter(), 10) || 0;
 
     if (this.wrongAttemptsCounter < WRONG_ATTEMPTS.step1.maxAttempts) {
+      this.setState({ isLoading: false });
       return;
     }
     const lastAttemptTimestamp = parseInt(await storage.getLastPasscodeAttempt(), 10);
@@ -138,6 +141,7 @@ class PasscodeModalBase extends PureComponent {
     if (milliseconds > 0) {
       this.lock({ milliseconds });
     }
+    this.setState({ isLoading: false });
   }
 
   componentWillUnmount() {
@@ -269,31 +273,39 @@ class PasscodeModalBase extends PureComponent {
     const {
       cancelBtnOnPress, showCancel, onResetPressed, isShowReset,
     } = this.props;
+    const { isLoading } = this.state;
 
     return (
       <View style={[styles.background, styles.container]}>
-        <View style={{ alignItems: 'center', justifyContent: 'center' }}>
-          {this.renderTitle()}
-          <Animatable.View ref={(ref) => { this.dotsView = ref; }} useNativeDriver style={styles.dotRow}>
-            {this.renderDots()}
-          </Animatable.View>
-          <View style={styles.buttonView}>
-            {isShowReset && (
-              <TouchableOpacity style={[styles.operationButton, styles.leftBottomButton]} onPress={onResetPressed}>
-                <Image source={references.images.passcodeReset} />
-              </TouchableOpacity>
-            )}
-            {showCancel && (
-              <TouchableOpacity style={[styles.operationButton, styles.leftBottomButton]} onPress={cancelBtnOnPress}>
-                <Image source={references.images.passcodeCancel} />
-              </TouchableOpacity>
-            )}
-            {this.renderButtons()}
-            <TouchableOpacity style={[styles.operationButton, styles.deleteButton]} onPress={this.onDeletePressed}>
-              <Image source={references.images.passcodeDelete} />
-            </TouchableOpacity>
-          </View>
-        </View>
+        {
+          isLoading && <Loader loading={isLoading} />
+        }
+        {
+          !isLoading && (
+            <View style={{ alignItems: 'center', justifyContent: 'center' }}>
+              {this.renderTitle()}
+              <Animatable.View ref={(ref) => { this.dotsView = ref; }} useNativeDriver style={styles.dotRow}>
+                {this.renderDots()}
+              </Animatable.View>
+              <View style={styles.buttonView}>
+                {isShowReset && (
+                  <TouchableOpacity style={[styles.operationButton, styles.leftBottomButton]} onPress={onResetPressed}>
+                    <Image source={references.images.passcodeReset} />
+                  </TouchableOpacity>
+                )}
+                {showCancel && (
+                  <TouchableOpacity style={[styles.operationButton, styles.leftBottomButton]} onPress={cancelBtnOnPress}>
+                    <Image source={references.images.passcodeCancel} />
+                  </TouchableOpacity>
+                )}
+                {this.renderButtons()}
+                <TouchableOpacity style={[styles.operationButton, styles.deleteButton]} onPress={this.onDeletePressed}>
+                  <Image source={references.images.passcodeDelete} />
+                </TouchableOpacity>
+              </View>
+            </View>
+          )
+        }
       </View>
     );
   }

--- a/src/components/common/passcode/passcode.modal.base.js
+++ b/src/components/common/passcode/passcode.modal.base.js
@@ -92,18 +92,26 @@ const styles = StyleSheet.create({
 class PasscodeModalBase extends PureComponent {
   constructor(props) {
     super(props);
-    const { title } = props;
+    const { title, locked } = props;
     this.state = {
       title,
       input: '',
+      locked,
     };
     this.onPressButton = this.onPressButton.bind(this);
     this.onDeletePressed = this.onDeletePressed.bind(this);
   }
 
+  componentWillReceiveProps(nextProps) {
+    const { locked } = nextProps;
+    this.setState({
+      locked,
+    });
+  }
+
   onPressButton(i) {
     // ignore everything when locked
-    const { locked } = this.props;
+    const { locked } = this.state;
     if (locked) return;
     const { passcodeOnFill } = this.props;
     this.setState((prevState) => ({ input: prevState.input + i }), () => {

--- a/src/components/common/passcode/passcode.modal.base.js
+++ b/src/components/common/passcode/passcode.modal.base.js
@@ -12,6 +12,8 @@ import references from '../../../assets/references';
 
 const buttonSize = 75;
 const dotSize = 13;
+
+const MAX_WRONG_ATTEMPTS = 5;
 const WAITING_TIME_MS = 5 * 1000 * 60;
 
 const styles = StyleSheet.create({
@@ -102,6 +104,7 @@ class PasscodeModalBase extends PureComponent {
     };
     this.onPressButton = this.onPressButton.bind(this);
     this.onDeletePressed = this.onDeletePressed.bind(this);
+    this.wrongAttemptsCounter = 0;
   }
 
   componentWillUnmount() {
@@ -110,6 +113,7 @@ class PasscodeModalBase extends PureComponent {
   }
 
   onPressButton(i) {
+    // ignore everything when locked
     const { locked } = this.state;
     if (locked) return;
     const { passcodeOnFill } = this.props;
@@ -137,6 +141,15 @@ class PasscodeModalBase extends PureComponent {
   rejectPasscord = (title) => {
     this.setState({ input: '', title }, () => this.dotsView.shake(800));
   };
+
+  handleWrongPasscode = () => {
+    this.wrongAttemptsCounter += 1;
+    if (this.wrongAttemptsCounter < MAX_WRONG_ATTEMPTS) {
+      this.rejectPasscord('modal.verifyPasscode.incorrect');
+      return;
+    }
+    this.lock();
+  }
 
   lock = () => {
     // TODO: load timer on start

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PasscodeModalBase from './passcode.modal.base';
 
+const MAX_ATTEMPTS = 2;
+
 class VerifyPasscodeModal extends PureComponent {
   constructor(props) {
     super(props);
@@ -19,6 +21,7 @@ class VerifyPasscodeModal extends PureComponent {
     this.passcodeFallback = passcodeFallback;
     this.passcodeOnFill = this.passcodeOnFill.bind(this);
     this.cancelBtnOnPress = this.cancelBtnOnPress.bind(this);
+    this.wrongAttemptsCounter = 0;
   }
 
   passcodeOnFill = async (input) => {
@@ -28,15 +31,21 @@ class VerifyPasscodeModal extends PureComponent {
       case 0:
       case 1:
         if (input === passcode) {
+          this.wrongAttemptsCounter = 0;
           this.baseModal.resetModal();
           this.closePasscodeModal();
           if (this.passcodeCallback) {
             this.passcodeCallback();
           }
         } else {
-          this.flowIndex = 1;
-          flow = _.find(this.flows, { index: this.flowIndex });
-          this.baseModal.rejectPasscord(flow.title);
+          this.wrongAttemptsCounter += 1;
+          if (this.wrongAttemptsCounter >= MAX_ATTEMPTS) {
+            this.baseModal.lock();
+          } else {
+            this.flowIndex = 1;
+            flow = _.find(this.flows, { index: this.flowIndex });
+            this.baseModal.rejectPasscord(flow.title);
+          }
         }
         break;
       default:

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -28,7 +28,7 @@ class VerifyPasscodeModal extends PureComponent {
   }
 
   componentDidMount() {
-    this.initialize();
+    this.initialize().then(this.setState({ isLoading: false }));
   }
 
   initialize = async () => {
@@ -49,18 +49,15 @@ class VerifyPasscodeModal extends PureComponent {
       }
     } catch (error) {
       console.error('Unexpected error: ', error);
-    } finally {
-      this.setState({ isLoading: false });
     }
   }
 
   lock = ({ milliseconds }) => {
-    // TODO: register string on translations file
-    this.baseModal.resetModal('You can try again in: ');
     this.setState({
       locked: true,
       timer: milliseconds,
     });
+    this.baseModal.resetModal('modal.verifyPasscode.tryAgainIn');
 
     // updates timer every 1 second
     const interval = setInterval(
@@ -72,6 +69,7 @@ class VerifyPasscodeModal extends PureComponent {
       this.setState({
         locked: false,
         timer: undefined,
+        title: 'modal.verifyPasscode.type',
       });
       this.baseModal.resetModal('modal.verifyPasscode.type');
       clearInterval(interval);

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PasscodeModalBase from './passcode.modal.base';
-import storage from '../../../common/storage';
+import { clearWrongAttempts } from './wrongPasscodeUtils';
 
 class VerifyPasscodeModal extends PureComponent {
   constructor(props) {
@@ -18,12 +18,12 @@ class VerifyPasscodeModal extends PureComponent {
 
   passcodeOnFill = async (input) => {
     const { passcode } = this.props;
+
     if (input === passcode) {
       this.baseModal.resetModal();
       this.closePasscodeModal();
-      // clears data from wrong attempts
-      storage.setLastPasscodeAttempt();
-      storage.setWrongPasscodeCounter(0);
+      clearWrongAttempts();
+
       if (this.passcodeCallback) {
         this.passcodeCallback();
       }

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -1,54 +1,32 @@
-import _ from 'lodash';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PasscodeModalBase from './passcode.modal.base';
 
-const MAX_ATTEMPTS = 2;
-
 class VerifyPasscodeModal extends PureComponent {
   constructor(props) {
     super(props);
-    this.flows = [
-      { index: 0, title: 'modal.verifyPasscode.type' },
-      { index: 1, title: 'modal.verifyPasscode.incorrect' },
-    ];
-    this.flowIndex = 0;
-    this.title = this.flows[0].title;
+    this.title = 'modal.verifyPasscode.type';
     const { closePasscodeModal, passcodeCallback, passcodeFallback } = this.props;
     this.closePasscodeModal = closePasscodeModal;
     this.passcodeCallback = passcodeCallback;
     this.passcodeFallback = passcodeFallback;
     this.passcodeOnFill = this.passcodeOnFill.bind(this);
     this.cancelBtnOnPress = this.cancelBtnOnPress.bind(this);
-    this.wrongAttemptsCounter = 0;
+    this.wrongAttemptsCounter = 0; // TODO: persist
   }
 
   passcodeOnFill = async (input) => {
     const { passcode } = this.props;
-    let flow = null;
-    switch (this.flowIndex) {
-      case 0:
-      case 1:
-        if (input === passcode) {
-          this.wrongAttemptsCounter = 0;
-          this.baseModal.resetModal();
-          this.closePasscodeModal();
-          if (this.passcodeCallback) {
-            this.passcodeCallback();
-          }
-        } else {
-          this.wrongAttemptsCounter += 1;
-          if (this.wrongAttemptsCounter >= MAX_ATTEMPTS) {
-            this.baseModal.lock();
-          } else {
-            this.flowIndex = 1;
-            flow = _.find(this.flows, { index: this.flowIndex });
-            this.baseModal.rejectPasscord(flow.title);
-          }
-        }
-        break;
-      default:
+    if (input === passcode) {
+      this.wrongAttemptsCounter = 0;
+      this.baseModal.resetModal();
+      this.closePasscodeModal();
+      if (this.passcodeCallback) {
+        this.passcodeCallback();
+      }
+    } else {
+      this.baseModal.handleWrongPasscode();
     }
   };
 

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -28,27 +28,28 @@ class VerifyPasscodeModal extends PureComponent {
   }
 
   componentDidMount() {
-    this.initialize().then(this.setState({ isLoading: false }));
+    this.initialize()
+      .then(this.setState({ isLoading: false }))
+      .catch((error) => {
+        console.error('This error should be reported', { error });
+      });
   }
 
   initialize = async () => {
-    try {
-      this.setState({ isLoading: true });
-      this.wrongAttemptsCounter = parseInt(await storage.getWrongPasscodeCounter(), 10) || 0;
+    this.setState({ isLoading: true });
+    const wrongAttemptsStorage = await storage.getWrongPasscodeCounter();
+    this.wrongAttemptsCounter = parseInt(wrongAttemptsStorage, 10) || 0;
 
-      if (this.wrongAttemptsCounter < WRONG_ATTEMPTS_STEPS.step1.maxAttempts) {
-        return;
-      }
-      const lastAttemptTimestamp = parseInt(await storage.getLastPasscodeAttempt(), 10);
-      const msSinceLastAttempt = Date.now() - lastAttemptTimestamp;
-      const { waitingMinutes } = getClosestStep({ numberOfAttempts: this.wrongAttemptsCounter });
-      const milliseconds = waitingMinutes * 1000 * 60 - msSinceLastAttempt;
+    if (this.wrongAttemptsCounter < WRONG_ATTEMPTS_STEPS.step1.maxAttempts) {
+      return;
+    }
+    const lastAttemptTimestamp = parseInt(await storage.getLastPasscodeAttempt(), 10);
+    const msSinceLastAttempt = Date.now() - lastAttemptTimestamp;
+    const { waitingMinutes } = getClosestStep({ numberOfAttempts: this.wrongAttemptsCounter });
+    const milliseconds = waitingMinutes * 1000 * 60 - msSinceLastAttempt;
 
-      if (milliseconds > 0) {
-        this.lock({ milliseconds });
-      }
-    } catch (error) {
-      console.error('Unexpected error: ', error);
+    if (milliseconds > 0) {
+      this.lock({ milliseconds });
     }
   }
 

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -2,18 +2,94 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PasscodeModalBase from './passcode.modal.base';
-import { clearWrongAttempts } from './wrongPasscodeUtils';
+import {
+  getClosestStep,
+  WRONG_ATTEMPTS_STEPS,
+  clearWrongAttempts,
+  getTimerString,
+} from './wrongPasscodeUtils';
+import storage from '../../../common/storage';
+import Loader from '../misc/loader';
 
 class VerifyPasscodeModal extends PureComponent {
   constructor(props) {
     super(props);
-    this.title = 'modal.verifyPasscode.type';
+    this.state = {
+      title: 'modal.verifyPasscode.type',
+      isLoading: false,
+      locked: false,
+    };
     const { closePasscodeModal, passcodeCallback, passcodeFallback } = this.props;
     this.closePasscodeModal = closePasscodeModal;
     this.passcodeCallback = passcodeCallback;
     this.passcodeFallback = passcodeFallback;
     this.passcodeOnFill = this.passcodeOnFill.bind(this);
     this.cancelBtnOnPress = this.cancelBtnOnPress.bind(this);
+  }
+
+  componentDidMount() {
+    this.initialize();
+  }
+
+  initialize = async () => {
+    try {
+      this.setState({ isLoading: true });
+      this.wrongAttemptsCounter = parseInt(await storage.getWrongPasscodeCounter(), 10) || 0;
+
+      if (this.wrongAttemptsCounter < WRONG_ATTEMPTS_STEPS.step1.maxAttempts) {
+        return;
+      }
+      const lastAttemptTimestamp = parseInt(await storage.getLastPasscodeAttempt(), 10);
+      const msSinceLastAttempt = Date.now() - lastAttemptTimestamp;
+      const { waitingMinutes } = getClosestStep({ numberOfAttempts: this.wrongAttemptsCounter });
+      const milliseconds = waitingMinutes * 1000 * 60 - msSinceLastAttempt;
+
+      if (milliseconds > 0) {
+        this.lock({ milliseconds });
+      }
+    } catch (error) {
+      console.error('Unexpected error: ', error);
+    } finally {
+      this.setState({ isLoading: false });
+    }
+  }
+
+  lock = ({ milliseconds }) => {
+    // TODO: register string on translations file
+    this.baseModal.resetModal('You can try again in: ');
+    this.setState({
+      locked: true,
+      timer: milliseconds,
+    });
+
+    // updates timer every 1 second
+    const interval = setInterval(
+      () => this.setState((prevState) => ({ timer: prevState.timer - 1000 })),
+      1000,
+    );
+
+    setTimeout(() => {
+      this.setState({
+        locked: false,
+        timer: undefined,
+      });
+      this.baseModal.resetModal('modal.verifyPasscode.type');
+      clearInterval(interval);
+    }, milliseconds);
+  }
+
+  handleWrongPasscode = () => {
+    this.wrongAttemptsCounter += 1;
+    storage.setWrongPasscodeCounter(this.wrongAttemptsCounter);
+
+    if (this.wrongAttemptsCounter < WRONG_ATTEMPTS_STEPS.step1.maxAttempts) {
+      // still doesn't reach the first step
+      this.baseModal.rejectPasscord('modal.verifyPasscode.incorrect');
+      return;
+    }
+    const { waitingMinutes } = getClosestStep({ numberOfAttempts: this.wrongAttemptsCounter });
+    storage.setLastPasscodeAttempt(Date.now());
+    this.lock({ milliseconds: waitingMinutes * 1000 * 60 });
   }
 
   passcodeOnFill = async (input) => {
@@ -28,7 +104,7 @@ class VerifyPasscodeModal extends PureComponent {
         this.passcodeCallback();
       }
     } else {
-      this.baseModal.handleWrongPasscode();
+      this.handleWrongPasscode();
     }
   };
 
@@ -40,13 +116,24 @@ class VerifyPasscodeModal extends PureComponent {
   };
 
   render() {
+    const {
+      title, isLoading, locked, timer,
+    } = this.state;
+    const timerString = timer ? getTimerString({ milliseconds: timer }) : '';
+
+    if (isLoading) {
+      return <Loader loading={isLoading} />;
+    }
+
     return (
       <PasscodeModalBase
         ref={(ref) => {
           this.baseModal = ref;
         }}
+        locked={locked}
         passcodeOnFill={this.passcodeOnFill}
-        title={this.title}
+        title={title}
+        timer={timerString}
         cancelBtnOnPress={this.cancelBtnOnPress}
         showCancel={!!this.passcodeFallback}
       />

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PasscodeModalBase from './passcode.modal.base';
+import storage from '../../../common/storage';
 
 class VerifyPasscodeModal extends PureComponent {
   constructor(props) {
@@ -13,15 +14,16 @@ class VerifyPasscodeModal extends PureComponent {
     this.passcodeFallback = passcodeFallback;
     this.passcodeOnFill = this.passcodeOnFill.bind(this);
     this.cancelBtnOnPress = this.cancelBtnOnPress.bind(this);
-    this.wrongAttemptsCounter = 0; // TODO: persist
   }
 
   passcodeOnFill = async (input) => {
     const { passcode } = this.props;
     if (input === passcode) {
-      this.wrongAttemptsCounter = 0;
       this.baseModal.resetModal();
       this.closePasscodeModal();
+      // clears data from wrong attempts
+      storage.setLastPasscodeAttempt();
+      storage.setWrongPasscodeCounter(0);
       if (this.passcodeCallback) {
         this.passcodeCallback();
       }

--- a/src/components/common/passcode/wrongPasscodeUtils.js
+++ b/src/components/common/passcode/wrongPasscodeUtils.js
@@ -1,0 +1,41 @@
+import storage from '../../../common/storage';
+
+export const WRONG_ATTEMPTS_STEPS = {
+  step1: {
+    maxAttempts: 6,
+    waitingMinutes: 1,
+  },
+  step2: {
+    maxAttempts: 7,
+    waitingMinutes: 5,
+  },
+  step3: {
+    maxAttempts: 8,
+    waitingMinutes: 15,
+  },
+  step4: {
+    maxAttempts: 10,
+    waitingMinutes: 60,
+  },
+};
+
+export const clearWrongAttempts = () => {
+  storage.setLastPasscodeAttempt();
+  storage.setWrongPasscodeCounter(0);
+};
+
+// returns most accurate WRONG_ATTEMPTS step value according to the current number of consecutive wrong attempts
+export const getClosestStep = ({ numberOfAttempts }) => {
+  let lastStep = WRONG_ATTEMPTS_STEPS.step1;
+  let lastStepDiff = numberOfAttempts - lastStep.maxAttempts;
+
+  Object.values(WRONG_ATTEMPTS_STEPS).forEach((step) => {
+    const currentDiff = numberOfAttempts - step.maxAttempts;
+
+    if (currentDiff >= 0 && lastStepDiff > currentDiff) {
+      lastStepDiff = currentDiff;
+      lastStep = step;
+    }
+  });
+  return lastStep;
+};

--- a/src/components/common/passcode/wrongPasscodeUtils.js
+++ b/src/components/common/passcode/wrongPasscodeUtils.js
@@ -39,3 +39,10 @@ export const getClosestStep = ({ numberOfAttempts }) => {
   });
   return lastStep;
 };
+
+export const getTimerString = ({ milliseconds }) => {
+  if (!milliseconds) return '';
+  const minutes = Math.floor(milliseconds / 60 / 1000).toString().padStart(2, '0');
+  const seconds = Math.floor((milliseconds % 60000) / 1000).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};

--- a/src/components/common/passcode/wrongPasscodeUtils.js
+++ b/src/components/common/passcode/wrongPasscodeUtils.js
@@ -20,8 +20,12 @@ export const WRONG_ATTEMPTS_STEPS = {
 };
 
 export const clearWrongAttempts = () => {
-  storage.setLastPasscodeAttempt();
-  storage.setWrongPasscodeCounter(0);
+  try {
+    storage.setLastPasscodeAttempt();
+    storage.setWrongPasscodeCounter(0);
+  } catch (error) {
+    console.error('Error cleaning wrong attempts', error);
+  }
 };
 
 // returns most accurate WRONG_ATTEMPTS step value according to the current number of consecutive wrong attempts


### PR DESCRIPTION
## Features
- Avoids users to enter passcodes on too many consecutive wrong attempts
- Adds countdown timer to show when users can retry
- Handles steps for retries dynamically
- Persists wrong attempts count and last attempt timestamp between sessions
- Adds loader while checking if user can already retry

## Known issues
- I just got the translation from Google so not sure if they are the most accurate
- It might be better to map props to state and read them on `componentWillReceiveProps` instead of using `baseModal.resetModal(...)`, but that would require a refactor of the base modal dependencies as well (reset passcode, create new passcode, wrong passcode

## How to test
- Wrong retries count and timer should persist between sessions (ie: closing and re-opening the app)
- With the provided configuration, the app should behave like this:
```
    STEP_1
    6 consecutive -> 1 minute wait
An iPhone will disable for 1 minute after six failed passcode attempts in a row
STEP_2
    7 consecutive -> 5 minutes
STEP_3
    8 consecutive -> 15 minutes
STEP_4
    10 or more consecutive -> 1 hour
```
- The steps can be changed on `src/components/common/passcode/wrongPasscodeUtils.js` -> `WRONG_ATTEMPTS_STEPS`

## Screenshots
<img width="346" alt="Screen Shot 2021-04-22 at 17 23 54" src="https://user-images.githubusercontent.com/8449567/115780470-94617d80-a38f-11eb-811f-2b26fb90db3d.png">
