### PR TITLE
fix: android bigint issue

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -17,7 +17,7 @@ if (typeof process === 'undefined') {
 
 process.browser = false;
 if (typeof Buffer === 'undefined') global.Buffer = require('buffer').Buffer;
-
+if (typeof BigInt === 'undefined') global.BigInt = require('big-integer');
 // global.location = global.location || { port: 80 }
 const isDev = typeof __DEV__ === 'boolean' && __DEV__;
 process.env.NODE_ENV = isDev ? 'development' : 'production';


### PR DESCRIPTION
We were having error when building for Android with the message: `Can't find variable: BigInt`
@jessgusclark found that we were missing some config in `shim.js` according to the doc in https://www.npmjs.com/package/@rsksmart/rns-resolver.js , under the section 'Usage in React Native'.
We tested locally, and it worked. 
