### PR TITLE
chore: set storage not 'migrable'

### DIFF
--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -1,6 +1,6 @@
 import Storage from 'react-native-storage';
 import AsyncStorage from '@react-native-community/async-storage';
-import RNSecureStorage from 'rn-secure-storage';
+import RNSecureStorage, { ACCESSIBLE } from 'rn-secure-storage';
 import _ from 'lodash';
 
 const KEY_WALLETS = 'WALLETS';
@@ -87,7 +87,6 @@ class RNStorage {
     });
   }
 
-
   /**
    *
    * @param {string} key
@@ -161,7 +160,9 @@ class RNStorage {
    * @param {string} value
    */
   static secureSet(key, value) {
-    return RNSecureStorage.set(key, value, {});
+    return RNSecureStorage.set(key, value, {
+      accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
   }
 
   /**


### PR DESCRIPTION
**Issue**
When the users resets/change phone, all data is migrated to the new phone, when for security reasons it shouldn't. The private data should 'live' only on the scope of the current device. 

**Tech description**
rWallet uses lib [rn-secure-storage](https://github.com/talut/rn-secure-storage#keychainaccessible-enum) for saving data in the device, from their docs they have some ways to set how to save data.
To fix it lets change to:
- **`WHEN_UNLOCKED_THIS_DEVICE_ONLY`**: The data in the keychain item can be accessed only while the device is unlocked by the user. Items with this attribute do not migrate to a new device.

**What do we store?**
- Passcode
- Mnemonic phrase
- Private key
- User password

**How to test it**
- Install the app in a new device with apple account set. 
- Create a new wallet with new seed.
- Create a new device.
- Import apple account.
- When opening the app, we shouldn't get any wallet already created.

