### PR TITLE
Report errors to the server when the DefaultError is thrown

### DIFF
--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -3,14 +3,20 @@ import VersionNumber from 'react-native-version-number';
 import ParseHelper from '../parse';
 
 const mockSend = (data) => {
-  console.log('@jesse', data);
+  console.log('@jesse, data  :', data);
+  console.log('@jesse, string:', JSON.stringify(data));
   Promise.resolve(true);
 };
 
 const ReportErrorToServer = ({ developerComment, errorObject }) => ParseHelper.getUser().then((parseUser) => {
+  // create the object to be sent
   const toServerObject = {
     comment: developerComment || '',
-    errorObject: errorObject.toString(),
+    errorObject: {
+      message: errorObject.message,
+      code: errorObject.code,
+      stack: errorObject.stack.toString(),
+    },
     userId: parseUser.id,
     username: parseUser.getUsername(),
     platform: getSystemName(),

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -13,31 +13,39 @@ const sendToServer = (data) => {
 };
 
 /**
+ * Handles error getting the user and the error if it can't send to the server. Both of these
+ * errors need to be caught so they don't crash the app.
+ * @param {Error} error
+ */
+const handleError = (error) => console.log(error);
+
+/**
  * Creates a report in JSON format and sends it to the server to be saved
  * @param {object} data
  * @param {Object} data.developerComment {string} a comment added by a developer for extra context
  * @param {Object} data.errorObject {Error} the error that was thrown
  * @param {Object} data.additionalInfo {Object} an optional JSON object that can provide extra information
  */
-const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) => ParseHelper.getUser().then((parseUser) => {
-  // create the object to be sent
-  const toServerObject = {
-    comment: developerComment || '',
-    additionalInfo: additionalInfo ? JSON.stringify(additionalInfo) : '',
-    errorObject: {
-      code: errorObject.code,
-      message: errorObject.message,
-      stack: errorObject.stack.toString(),
-    },
-    userId: parseUser.id,
-    username: parseUser.getUsername(),
-    platform: getSystemName(),
-    appVersion: VersionNumber.appVersion,
-  };
+const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) => ParseHelper.getUser()
+  .then((parseUser) => {
+    // create the object to be sent
+    const toServerObject = {
+      comment: developerComment || '',
+      additionalInfo: additionalInfo ? JSON.stringify(additionalInfo) : '',
+      errorObject: {
+        code: errorObject.code,
+        message: errorObject.message,
+        stack: errorObject.stack.toString(),
+      },
+      userId: parseUser.id,
+      username: parseUser.getUsername(),
+      platform: getSystemName(),
+      appVersion: VersionNumber.appVersion,
+    };
 
-  // send object to server
-  sendToServer(toServerObject)
-    .catch((error) => console.log(error));
-});
+    // send object to server
+    sendToServer(toServerObject).catch(handleError);
+  })
+  .catch(handleError);
 
 export default ReportErrorToServer;

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -1,0 +1,24 @@
+import { getSystemName } from 'react-native-device-info';
+import VersionNumber from 'react-native-version-number';
+import ParseHelper from '../parse';
+
+const mockSend = (data) => {
+  console.log('@jesse', data);
+  Promise.resolve(true);
+};
+
+const ReportErrorToServer = ({ developerComment, errorObject }) => ParseHelper.getUser().then((parseUser) => {
+  const toServerObject = {
+    comment: developerComment || '',
+    errorObject: errorObject.toString(),
+    userId: parseUser.id,
+    username: parseUser.getUsername(),
+    platform: getSystemName(),
+    appVersion: VersionNumber.appVersion,
+  };
+
+  // send object to server
+  mockSend(toServerObject);
+});
+
+export default ReportErrorToServer;

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -36,7 +36,9 @@ const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) 
     console.log('[ReportErrorToServer]', toServerObject);
 
     // send object to server
-    ParseHelper.sendErrorReport(toServerObject).catch(handleError);
+    ParseHelper.sendErrorReport(toServerObject)
+      .then(() => console.log('[ReportErrorToServer] Report sent'))
+      .catch(handleError);
   })
   .catch(handleError);
 

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -15,7 +15,7 @@ const handleError = (error) => console.log(error);
  * @param {Object} data.errorObject {Error} the error that was thrown
  * @param {Object} data.additionalInfo {Object} an optional JSON object that can provide extra information
  */
-const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) => ParseHelper.getUser()
+const reportErrorToServer = ({ developerComment, errorObject, additionalInfo }) => ParseHelper.getUser()
   .then((parseUser) => {
     // create the object to be sent
     const toServerObject = {
@@ -33,13 +33,13 @@ const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) 
     };
 
     // console.log will be removed in the future
-    console.log('[ReportErrorToServer]', toServerObject);
+    console.log('[reportErrorToServer]', toServerObject);
 
     // send object to server
     ParseHelper.sendErrorReport(toServerObject)
-      .then(() => console.log('[ReportErrorToServer] Report sent'))
+      .then(() => console.log('[reportErrorToServer] Report sent'))
       .catch(handleError);
   })
   .catch(handleError);
 
-export default ReportErrorToServer;
+export default reportErrorToServer;

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -3,19 +3,8 @@ import VersionNumber from 'react-native-version-number';
 import ParseHelper from '../parse';
 
 /**
- * Send the data object to the server. Mocked right now and will be replaced in the future
- * @param {Object} data object that is sent
- */
-const sendToServer = (data) => {
-  console.log('@jesse, data  :', data);
-  console.log('@jesse, string:', JSON.stringify(data));
-  return Promise.resolve(true);
-};
-
-/**
  * Handles error getting the user and the error if it can't send to the server. Both of these
  * errors need to be caught so they don't crash the app.
- * @param {Error} error
  */
 const handleError = (error) => console.log(error);
 
@@ -43,8 +32,11 @@ const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) 
       appVersion: VersionNumber.appVersion,
     };
 
+    // console.log will be removed in the future
+    console.log('[ReportErrorToServer]', toServerObject);
+
     // send object to server
-    sendToServer(toServerObject).catch(handleError);
+    ParseHelper.sendErrorReport(toServerObject).catch(handleError);
   })
   .catch(handleError);
 

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -2,19 +2,31 @@ import { getSystemName } from 'react-native-device-info';
 import VersionNumber from 'react-native-version-number';
 import ParseHelper from '../parse';
 
-const mockSend = (data) => {
+/**
+ * Send the data object to the server. Mocked right now and will be replaced in the future
+ * @param {Object} data object that is sent
+ */
+const sendToServer = (data) => {
   console.log('@jesse, data  :', data);
   console.log('@jesse, string:', JSON.stringify(data));
-  Promise.resolve(true);
+  return Promise.resolve(true);
 };
 
-const ReportErrorToServer = ({ developerComment, errorObject }) => ParseHelper.getUser().then((parseUser) => {
+/**
+ * Creates a report in JSON format and sends it to the server to be saved
+ * @param {object} data
+ * @param {Object} data.developerComment {string} a comment added by a developer for extra context
+ * @param {Object} data.errorObject {Error} the error that was thrown
+ * @param {Object} data.additionalInfo {Object} an optional JSON object that can provide extra information
+ */
+const ReportErrorToServer = ({ developerComment, errorObject, additionalInfo }) => ParseHelper.getUser().then((parseUser) => {
   // create the object to be sent
   const toServerObject = {
     comment: developerComment || '',
+    additionalInfo: additionalInfo ? JSON.stringify(additionalInfo) : '',
     errorObject: {
-      message: errorObject.message,
       code: errorObject.code,
+      message: errorObject.message,
       stack: errorObject.stack.toString(),
     },
     userId: parseUser.id,
@@ -24,7 +36,8 @@ const ReportErrorToServer = ({ developerComment, errorObject }) => ParseHelper.g
   };
 
   // send object to server
-  mockSend(toServerObject);
+  sendToServer(toServerObject)
+    .catch((error) => console.log(error));
 });
 
 export default ReportErrorToServer;

--- a/src/common/error/report.error.js
+++ b/src/common/error/report.error.js
@@ -1,6 +1,20 @@
 import { getSystemName } from 'react-native-device-info';
 import VersionNumber from 'react-native-version-number';
 import ParseHelper from '../parse';
+import ERROR_CODE from './error.code';
+
+/**
+ * A list of codes that should be reported
+ * @param {number} errorCode number
+ */
+export const shouldReportError = (errorCode) => {
+  switch (errorCode) {
+    case ERROR_CODE.ERR_REQUEST_TIMEOUT:
+    case ERROR_CODE.TIME_OUT:
+      return true;
+    default: return false;
+  }
+}
 
 /**
  * Handles error getting the user and the error if it can't send to the server. Both of these

--- a/src/common/parse.js
+++ b/src/common/parse.js
@@ -353,6 +353,10 @@ class ParseHelper {
     });
   }
 
+  static sendErrorReport(error) {
+    return Parse.Cloud.run('logError', { error });
+  }
+
   /**
    * Subscribe to a Live Query channel also-known-as Parse Class
    * @param {*} collection

--- a/src/pages/wallet/add.custom.token.confirm.js
+++ b/src/pages/wallet/add.custom.token.confirm.js
@@ -170,6 +170,11 @@ class AddCustomToken extends Component {
         this.setState({ balance: common.weiToCoin(result.balance, this.precision) });
       } catch (error) {
         console.log('getUserTokenBalance, error: ', error);
+        ReportErrorToServer({
+          developerComment: 'add custom token confirm, requestBalance()',
+          additionalInfo: { wallet, contractAddress },
+          errorObject: error,
+        });
       } finally {
         this.setState({ isLoadingBalance: false });
       }

--- a/src/pages/wallet/add.custom.token.confirm.js
+++ b/src/pages/wallet/add.custom.token.confirm.js
@@ -20,6 +20,7 @@ import { createErrorNotification, getErrorNotification, getDefaultErrorNotificat
 import common from '../../common/common';
 import CancelablePromiseUtil from '../../common/cancelable.promise.util';
 import { WalletType } from '../../common/constants';
+import ReportErrorToServer from '../../common/error/report.error';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -137,6 +138,14 @@ class AddCustomToken extends Component {
         });
       } catch (error) {
         const notification = getErrorNotification(error.code) || getDefaultErrorNotification();
+
+        if (!getErrorNotification(error.code)) {
+          ReportErrorToServer({
+            developerComment: 'Add custom token confirm, onComfirmPressed',
+            additionalInfo: { symbol, address, chain },
+            errorObject: error,
+          });
+        }
         addNotification(notification);
       } finally {
         this.setState({ isLoading: false });

--- a/src/pages/wallet/add.custom.token.confirm.js
+++ b/src/pages/wallet/add.custom.token.confirm.js
@@ -20,7 +20,7 @@ import { createErrorNotification, getErrorNotification, getDefaultErrorNotificat
 import common from '../../common/common';
 import CancelablePromiseUtil from '../../common/cancelable.promise.util';
 import { WalletType } from '../../common/constants';
-import ReportErrorToServer from '../../common/error/report.error';
+import reportErrorToServer from '../../common/error/report.error';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -140,7 +140,7 @@ class AddCustomToken extends Component {
         const notification = getErrorNotification(error.code) || getDefaultErrorNotification();
 
         if (!getErrorNotification(error.code)) {
-          ReportErrorToServer({
+          reportErrorToServer({
             developerComment: 'Add custom token confirm, onComfirmPressed',
             additionalInfo: { symbol, address, chain },
             errorObject: error,
@@ -170,7 +170,7 @@ class AddCustomToken extends Component {
         this.setState({ balance: common.weiToCoin(result.balance, this.precision) });
       } catch (error) {
         console.log('getUserTokenBalance, error: ', error);
-        ReportErrorToServer({
+        reportErrorToServer({
           developerComment: 'add custom token confirm, requestBalance()',
           additionalInfo: { wallet, contractAddress },
           errorObject: error,

--- a/src/pages/wallet/add.custom.token.confirm.js
+++ b/src/pages/wallet/add.custom.token.confirm.js
@@ -20,7 +20,7 @@ import { createErrorNotification, getErrorNotification, getDefaultErrorNotificat
 import common from '../../common/common';
 import CancelablePromiseUtil from '../../common/cancelable.promise.util';
 import { WalletType } from '../../common/constants';
-import reportErrorToServer from '../../common/error/report.error';
+import reportErrorToServer, { shouldReportError } from '../../common/error/report.error';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -137,9 +137,10 @@ class AddCustomToken extends Component {
           symbol, type, contractAddress: address, precision, chain, name,
         });
       } catch (error) {
-        const notification = getErrorNotification(error.code) || getDefaultErrorNotification();
+        const decodedNotification = getErrorNotification(error.code);
+        const notification = decodedNotification || getDefaultErrorNotification();
 
-        if (!getErrorNotification(error.code)) {
+        if (!decodedNotification || shouldReportError(error.code)) {
           reportErrorToServer({
             developerComment: 'Add custom token confirm, onComfirmPressed',
             additionalInfo: { symbol, address, chain },

--- a/src/pages/wallet/add.custom.token.js
+++ b/src/pages/wallet/add.custom.token.js
@@ -23,6 +23,7 @@ import { WalletType } from '../../common/constants';
 import { InvalidAddressError } from '../../common/error';
 import ConvertAddressConfirmation from '../../components/wallet/convert.address.confirmation';
 import { strings } from '../../common/i18n';
+import ReportErrorToServer from '../../common/error/report.error';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -122,6 +123,15 @@ class AddCustomToken extends Component {
       } catch (error) {
         const { addNotification } = this.props;
         const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification();
+
+        if (!getErrorNotification(error.code)) {
+          ReportErrorToServer({
+            developerComment: 'Add custom token, onPressed',
+            additionalInfo: { address, type },
+            errorObject: error,
+          });
+        }
+
         addNotification(notification);
       }
     }
@@ -148,6 +158,15 @@ class AddCustomToken extends Component {
       } catch (error) {
         console.log('getTokenBasicInfo, error: ', error);
         const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification();
+
+        if (!getErrorNotification(error.code)) {
+          ReportErrorToServer({
+            developerComment: 'Add custom token, addToken',
+            additionalInfo: { contractAddress, chain, type },
+            errorObject: error,
+          });
+        }
+
         addNotification(notification);
       } finally {
         this.setState({ isLoading: false });

--- a/src/pages/wallet/add.custom.token.js
+++ b/src/pages/wallet/add.custom.token.js
@@ -122,9 +122,10 @@ class AddCustomToken extends Component {
         this.addToken();
       } catch (error) {
         const { addNotification } = this.props;
-        const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification();
+        const decodedNotification = getErrorNotification(error.code, 'button.retry');
+        const notification = decodedNotification || getDefaultErrorNotification();
 
-        if (!getErrorNotification(error.code)) {
+        if (!decodedNotification) {
           reportErrorToServer({
             developerComment: 'Add custom token, onPressed',
             additionalInfo: { address, type },
@@ -157,9 +158,10 @@ class AddCustomToken extends Component {
         });
       } catch (error) {
         console.log('getTokenBasicInfo, error: ', error);
-        const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification();
+        const decodedNotification = getErrorNotification(error.code, 'button.retry');
+        const notification = decodedNotification || getDefaultErrorNotification();
 
-        if (!getErrorNotification(error.code)) {
+        if (!decodedNotification) {
           reportErrorToServer({
             developerComment: 'Add custom token, addToken',
             additionalInfo: { contractAddress, chain, type },

--- a/src/pages/wallet/add.custom.token.js
+++ b/src/pages/wallet/add.custom.token.js
@@ -23,7 +23,7 @@ import { WalletType } from '../../common/constants';
 import { InvalidAddressError } from '../../common/error';
 import ConvertAddressConfirmation from '../../components/wallet/convert.address.confirmation';
 import { strings } from '../../common/i18n';
-import reportErrorToServer from '../../common/error/report.error';
+import reportErrorToServer, { shouldReportError } from '../../common/error/report.error';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -125,7 +125,7 @@ class AddCustomToken extends Component {
         const decodedNotification = getErrorNotification(error.code, 'button.retry');
         const notification = decodedNotification || getDefaultErrorNotification();
 
-        if (!decodedNotification) {
+        if (!decodedNotification || shouldReportError(error.code)) {
           reportErrorToServer({
             developerComment: 'Add custom token, onPressed',
             additionalInfo: { address, type },
@@ -161,7 +161,7 @@ class AddCustomToken extends Component {
         const decodedNotification = getErrorNotification(error.code, 'button.retry');
         const notification = decodedNotification || getDefaultErrorNotification();
 
-        if (!decodedNotification) {
+        if (!decodedNotification || shouldReportError(error.code)) {
           reportErrorToServer({
             developerComment: 'Add custom token, addToken',
             additionalInfo: { contractAddress, chain, type },

--- a/src/pages/wallet/add.custom.token.js
+++ b/src/pages/wallet/add.custom.token.js
@@ -23,7 +23,7 @@ import { WalletType } from '../../common/constants';
 import { InvalidAddressError } from '../../common/error';
 import ConvertAddressConfirmation from '../../components/wallet/convert.address.confirmation';
 import { strings } from '../../common/i18n';
-import ReportErrorToServer from '../../common/error/report.error';
+import reportErrorToServer from '../../common/error/report.error';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -125,7 +125,7 @@ class AddCustomToken extends Component {
         const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification();
 
         if (!getErrorNotification(error.code)) {
-          ReportErrorToServer({
+          reportErrorToServer({
             developerComment: 'Add custom token, onPressed',
             additionalInfo: { address, type },
             errorObject: error,
@@ -160,7 +160,7 @@ class AddCustomToken extends Component {
         const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification();
 
         if (!getErrorNotification(error.code)) {
-          ReportErrorToServer({
+          reportErrorToServer({
             developerComment: 'Add custom token, addToken',
             additionalInfo: { contractAddress, chain, type },
             errorObject: error,

--- a/src/pages/wallet/rns/create.js
+++ b/src/pages/wallet/rns/create.js
@@ -237,9 +237,10 @@ class RnsAddress extends Component {
       result = await parse.isSubdomainAvailable(queryParams);
     } catch (error) {
       console.log(error);
-      const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification('button.retry');
+      const decodedNotification = getErrorNotification(error.code, 'button.retry');
+      const notification = decodedNotification || getDefaultErrorNotification();
 
-      if (!getErrorNotification(error.code)) {
+      if (!decodedNotification) {
         reportErrorToServer({
           developerComment: 'Create subdomain',
           additionalInfo: { queryParams },

--- a/src/pages/wallet/rns/create.js
+++ b/src/pages/wallet/rns/create.js
@@ -31,7 +31,7 @@ import CreateRnsConfirmation from '../../../components/rns/create.rns.confirmati
 import SubdomainUnavailableNotification from '../../../components/rns/subdomain.unavailable.notification';
 import common from '../../../common/common';
 import TypeTag from '../../../components/common/misc/type.tag';
-import reportErrorToServer from '../../../common/error/report.error';
+import reportErrorToServer, { shouldReportError } from '../../../common/error/report.error';
 
 const SUBDOMAIN_LENGTH_MIN = 3;
 const SUBDOMAIN_LENGTH_MAX = 12;
@@ -240,7 +240,7 @@ class RnsAddress extends Component {
       const decodedNotification = getErrorNotification(error.code, 'button.retry');
       const notification = decodedNotification || getDefaultErrorNotification();
 
-      if (!decodedNotification) {
+      if (!decodedNotification || shouldReportError(error.code)) {
         reportErrorToServer({
           developerComment: 'Create subdomain',
           additionalInfo: { queryParams },

--- a/src/pages/wallet/rns/create.js
+++ b/src/pages/wallet/rns/create.js
@@ -31,7 +31,7 @@ import CreateRnsConfirmation from '../../../components/rns/create.rns.confirmati
 import SubdomainUnavailableNotification from '../../../components/rns/subdomain.unavailable.notification';
 import common from '../../../common/common';
 import TypeTag from '../../../components/common/misc/type.tag';
-import ReportErrorToServer from '../../../common/error/report.error';
+import reportErrorToServer from '../../../common/error/report.error';
 
 const SUBDOMAIN_LENGTH_MIN = 3;
 const SUBDOMAIN_LENGTH_MAX = 12;
@@ -240,7 +240,7 @@ class RnsAddress extends Component {
       const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification('button.retry');
 
       if (!getErrorNotification(error.code)) {
-        ReportErrorToServer({
+        reportErrorToServer({
           developerComment: 'Create subdomain',
           additionalInfo: { queryParams },
           errorObject: error,

--- a/src/pages/wallet/rns/create.js
+++ b/src/pages/wallet/rns/create.js
@@ -31,6 +31,7 @@ import CreateRnsConfirmation from '../../../components/rns/create.rns.confirmati
 import SubdomainUnavailableNotification from '../../../components/rns/subdomain.unavailable.notification';
 import common from '../../../common/common';
 import TypeTag from '../../../components/common/misc/type.tag';
+import ReportErrorToServer from '../../../common/error/report.error';
 
 const SUBDOMAIN_LENGTH_MIN = 3;
 const SUBDOMAIN_LENGTH_MAX = 12;
@@ -237,6 +238,15 @@ class RnsAddress extends Component {
     } catch (error) {
       console.log(error);
       const notification = getErrorNotification(error.code, 'button.retry') || getDefaultErrorNotification('button.retry');
+
+      if (!getErrorNotification(error.code)) {
+        ReportErrorToServer({
+          developerComment: 'Create subdomain',
+          additionalInfo: { queryParams },
+          errorObject: error,
+        });
+      }
+
       addNotification(notification);
       return;
     } finally {

--- a/src/pages/wallet/transfer.js
+++ b/src/pages/wallet/transfer.js
@@ -35,7 +35,7 @@ import {
 } from '../../common/error';
 import InvalidRskAddressConfirmation from '../../components/wallet/invalid.rskaddress.confirmation';
 import { domainToAddress } from './rns/domainToAddress';
-import ReportErrorToServer from '../../common/error/report.error';
+import reportErrorToServer from '../../common/error/report.error';
 
 const MEMO_NUM_OF_LINES = 8;
 const MEMO_LINE_HEIGHT = 15;
@@ -635,7 +635,7 @@ class Transfer extends Component {
     const notification = getErrorNotification(error.code) || getDefaultErrorNotification();
 
     if (!getErrorNotification(error.code)) {
-      ReportErrorToServer({ developerComment: 'transfer', errorObject: error });
+      reportErrorToServer({ developerComment: 'transfer', errorObject: error });
     }
 
     addNotification(notification);

--- a/src/pages/wallet/transfer.js
+++ b/src/pages/wallet/transfer.js
@@ -35,6 +35,7 @@ import {
 } from '../../common/error';
 import InvalidRskAddressConfirmation from '../../components/wallet/invalid.rskaddress.confirmation';
 import { domainToAddress } from './rns/domainToAddress';
+import ReportErrorToServer from '../../common/error/report.error';
 
 const MEMO_NUM_OF_LINES = 8;
 const MEMO_LINE_HEIGHT = 15;
@@ -632,6 +633,11 @@ class Transfer extends Component {
   addErrorNotification = (error) => {
     const { addNotification } = this.props;
     const notification = getErrorNotification(error.code) || getDefaultErrorNotification();
+
+    if (!getErrorNotification(error.code)) {
+      ReportErrorToServer({ developerComment: 'transfer', errorObject: error });
+    }
+
     addNotification(notification);
   }
 

--- a/src/pages/wallet/transfer.js
+++ b/src/pages/wallet/transfer.js
@@ -632,9 +632,10 @@ class Transfer extends Component {
 
   addErrorNotification = (error) => {
     const { addNotification } = this.props;
-    const notification = getErrorNotification(error.code) || getDefaultErrorNotification();
+    const decodedNotification = getErrorNotification(error.code);
+    const notification = decodedNotification || getDefaultErrorNotification();
 
-    if (!getErrorNotification(error.code)) {
+    if (!decodedNotification) {
       reportErrorToServer({ developerComment: 'transfer', errorObject: error });
     }
 

--- a/src/pages/wallet/wallet.connect/index.js
+++ b/src/pages/wallet/wallet.connect/index.js
@@ -33,7 +33,7 @@ import fontFamily from '../../../assets/styles/font.family';
 import appActions from '../../../redux/app/actions';
 import coinType from '../../../common/wallet/cointype';
 import { InsufficientRbtcError } from '../../../common/error';
-import ReportErrorToServer from '../../../common/error/report.error';
+import reportErrorToServer from '../../../common/error/report.error';
 
 const { MAINNET, TESTNET } = NETWORK;
 
@@ -300,7 +300,7 @@ class WalletConnectPage extends Component {
       });
     } catch (error) {
       console.log('init wallet error: ', error);
-      ReportErrorToServer({
+      reportErrorToServer({
         developerComment: 'walletConnect: initWalletConnect',
         additionalInfo: { uri },
         errorObject: error,
@@ -593,7 +593,7 @@ class WalletConnectPage extends Component {
       }
     } catch (error) {
       console.log('popupOperationModal error: ', error);
-      ReportErrorToServer({
+      reportErrorToServer({
         developerComment: 'walletConnect: popupOperationModal',
         errorObject: error,
       });
@@ -669,7 +669,7 @@ class WalletConnectPage extends Component {
       }
     } catch (error) {
       console.log('handleCallRequest error: ', error);
-      ReportErrorToServer({
+      reportErrorToServer({
         developerComment: 'walletConnect: handleCallRequest',
         errorObject: error,
       });

--- a/src/pages/wallet/wallet.connect/index.js
+++ b/src/pages/wallet/wallet.connect/index.js
@@ -33,6 +33,7 @@ import fontFamily from '../../../assets/styles/font.family';
 import appActions from '../../../redux/app/actions';
 import coinType from '../../../common/wallet/cointype';
 import { InsufficientRbtcError } from '../../../common/error';
+import ReportErrorToServer from '../../../common/error/report.error';
 
 const { MAINNET, TESTNET } = NETWORK;
 
@@ -299,6 +300,11 @@ class WalletConnectPage extends Component {
       });
     } catch (error) {
       console.log('init wallet error: ', error);
+      ReportErrorToServer({
+        developerComment: 'walletConnect: initWalletConnect',
+        additionalInfo: { uri },
+        errorObject: error,
+      });
       throw error;
     }
   }
@@ -587,6 +593,10 @@ class WalletConnectPage extends Component {
       }
     } catch (error) {
       console.log('popupOperationModal error: ', error);
+      ReportErrorToServer({
+        developerComment: 'walletConnect: popupOperationModal',
+        errorObject: error,
+      });
       this.handleError(error);
     }
   }
@@ -659,6 +669,10 @@ class WalletConnectPage extends Component {
       }
     } catch (error) {
       console.log('handleCallRequest error: ', error);
+      ReportErrorToServer({
+        developerComment: 'walletConnect: handleCallRequest',
+        errorObject: error,
+      });
       throw error;
     }
   }

--- a/src/redux/price/saga.js
+++ b/src/redux/price/saga.js
@@ -5,8 +5,7 @@ import { eventChannel } from 'redux-saga';
 import actions from './actions';
 import ParseHelper from '../../common/parse';
 import parseDataUtil from '../../common/parseDataUtil';
-import ReportErrorToServer from '../../common/error/report.error';
-
+import reportErrorToServer from '../../common/error/report.error';
 
 function createSocketChannel(socket) {
   return eventChannel((emitter) => {
@@ -56,7 +55,7 @@ function* fetchPricesRequest() {
     yield put({ type: actions.PRICE_OBJECT_UPDATED, data: prices });
   } catch (error) {
     console.log('initPriceSocketRequest.fetchPrices, error:', error);
-    ReportErrorToServer({
+    reportErrorToServer({
       developerComment: 'redux saga price: fetchPricesRequest',
       errorObject: error,
     });
@@ -87,7 +86,7 @@ function* subscribePrices() {
     }
   } catch (err) {
     console.log('socket error:', err);
-    ReportErrorToServer({
+    reportErrorToServer({
       developerComment: 'redux saga price: subscribePrices',
       errorObject: err,
     });

--- a/src/redux/price/saga.js
+++ b/src/redux/price/saga.js
@@ -5,6 +5,7 @@ import { eventChannel } from 'redux-saga';
 import actions from './actions';
 import ParseHelper from '../../common/parse';
 import parseDataUtil from '../../common/parseDataUtil';
+import ReportErrorToServer from '../../common/error/report.error';
 
 
 function createSocketChannel(socket) {
@@ -55,6 +56,10 @@ function* fetchPricesRequest() {
     yield put({ type: actions.PRICE_OBJECT_UPDATED, data: prices });
   } catch (error) {
     console.log('initPriceSocketRequest.fetchPrices, error:', error);
+    ReportErrorToServer({
+      developerComment: 'redux saga price: fetchPricesRequest',
+      errorObject: error,
+    });
   }
 }
 
@@ -82,6 +87,10 @@ function* subscribePrices() {
     }
   } catch (err) {
     console.log('socket error:', err);
+    ReportErrorToServer({
+      developerComment: 'redux saga price: subscribePrices',
+      errorObject: err,
+    });
   } finally {
     if (yield cancelled()) {
       socketChannel.close();

--- a/src/redux/wallet/saga.js
+++ b/src/redux/wallet/saga.js
@@ -10,6 +10,7 @@ import CoinSwitchHelper from '../../common/coinswitch.helper';
 import parseDataUtil from '../../common/parseDataUtil';
 
 import { createErrorNotification } from '../../common/notification.controller';
+import ReportErrorToServer from '../../common/error/report.error';
 
 function* createKeyRequest(action) {
   const {
@@ -75,6 +76,12 @@ function* addTokenRequest(action) {
     console.log(error);
     if (error.message === 'err.exsistedtoken') {
       yield put({ type: actions.SET_ADD_TOKEN_RESULT, value: { state: 'error', error } });
+    } else {
+      ReportErrorToServer({
+        developerComment: 'redux saga wallet: addTokenRequest',
+        additionalInfo: { token },
+        errorObject: error,
+      });
     }
   }
 }
@@ -155,6 +162,10 @@ function* fetchTokensRequest() {
     });
   } catch (error) {
     console.log('fetchTokensRequest, error:', error);
+    ReportErrorToServer({
+      developerComment: 'redux saga wallet: fetchTokensRequest',
+      errorObject: error,
+    });
   }
 }
 
@@ -278,6 +289,10 @@ function* fetchTransactions(action) {
     addTokenTransactions(token, transactions);
   } catch (error) {
     console.log('initLiveQueryTransactionsRequest.fetchTransactions, error:', error);
+    ReportErrorToServer({
+      developerComment: 'redux saga wallet: fetchTransactions',
+      errorObject: error,
+    });
   } finally {
     yield put({ type: actions.FETCH_TRANSACTIONS_RESULT, timestamp });
   }
@@ -364,6 +379,10 @@ function* fetchBlockHeightsRequest() {
     });
   } catch (error) {
     console.log('initLiveQueryTransactionsRequest.fetchBlockHeights, error:', error);
+    ReportErrorToServer({
+      developerComment: 'redux saga wallet: fetchBlockHeightsRequest',
+      errorObject: error,
+    });
   }
 }
 
@@ -419,6 +438,10 @@ function* getBalanceRequest(action) {
     yield put({ type: actions.FETCH_TOKENS_RESULT, value: [item] });
   } catch (error) {
     console.log('getBalanceRequest, error:', error);
+    ReportErrorToServer({
+      developerComment: 'redux saga wallet: getBalanceRequest',
+      errorObject: error,
+    });
   }
 }
 

--- a/src/redux/wallet/saga.js
+++ b/src/redux/wallet/saga.js
@@ -10,7 +10,7 @@ import CoinSwitchHelper from '../../common/coinswitch.helper';
 import parseDataUtil from '../../common/parseDataUtil';
 
 import { createErrorNotification } from '../../common/notification.controller';
-import ReportErrorToServer from '../../common/error/report.error';
+import reportErrorToServer from '../../common/error/report.error';
 
 function* createKeyRequest(action) {
   const {
@@ -77,7 +77,7 @@ function* addTokenRequest(action) {
     if (error.message === 'err.exsistedtoken') {
       yield put({ type: actions.SET_ADD_TOKEN_RESULT, value: { state: 'error', error } });
     } else {
-      ReportErrorToServer({
+      reportErrorToServer({
         developerComment: 'redux saga wallet: addTokenRequest',
         additionalInfo: { token },
         errorObject: error,
@@ -162,7 +162,7 @@ function* fetchTokensRequest() {
     });
   } catch (error) {
     console.log('fetchTokensRequest, error:', error);
-    ReportErrorToServer({
+    reportErrorToServer({
       developerComment: 'redux saga wallet: fetchTokensRequest',
       errorObject: error,
     });
@@ -289,7 +289,7 @@ function* fetchTransactions(action) {
     addTokenTransactions(token, transactions);
   } catch (error) {
     console.log('initLiveQueryTransactionsRequest.fetchTransactions, error:', error);
-    ReportErrorToServer({
+    reportErrorToServer({
       developerComment: 'redux saga wallet: fetchTransactions',
       errorObject: error,
     });
@@ -379,7 +379,7 @@ function* fetchBlockHeightsRequest() {
     });
   } catch (error) {
     console.log('initLiveQueryTransactionsRequest.fetchBlockHeights, error:', error);
-    ReportErrorToServer({
+    reportErrorToServer({
       developerComment: 'redux saga wallet: fetchBlockHeightsRequest',
       errorObject: error,
     });
@@ -438,7 +438,7 @@ function* getBalanceRequest(action) {
     yield put({ type: actions.FETCH_TOKENS_RESULT, value: [item] });
   } catch (error) {
     console.log('getBalanceRequest, error:', error);
-    ReportErrorToServer({
+    reportErrorToServer({
       developerComment: 'redux saga wallet: getBalanceRequest',
       errorObject: error,
     });


### PR DESCRIPTION
## Rational

Most of the errors this will be used with will be called from code files, however, some do occur within components. Until the code is separated, this module should be able to be called from anywhere.

It allows the developer to send optional parameters `developerComment` and `additionalInfo` to provide information that may not be in the error.

- `developerComment` could be the location of the error, or part of the process, or something where the developer could search for the string in the code and find the location quickly.
- `additionalInfo` could be the address of the user, or the subdomain they are trying to register, or any other information that would be helpful.

## Initial triggers

In this initial batch of errors, they are triggered where the getDefaultError() is found. This is the error that shows the user 'Internal server error'. 

It also will send a report in a few places where an error was caught and then console.log out. These errors may be caught at a higher level and not needed, but that is anyone's guess. 

## wanna test it?

There is a sister branch called `error-reporting-manual-trigger` that you can clone and run. Navigate to the "Me" section, and under "settings" the first item will be 'Internal Server Error' or the equivalent in your language. Click it! It will send an error to the server.

![Screen Shot 2021-05-06 at 2 13 18 PM](https://user-images.githubusercontent.com/766679/117289409-3778c380-ae75-11eb-9e7a-a9d6310ffdd5.png)

This sister branch **should not be merged** [due to this commit](https://github.com/rsksmart/rwallet/commit/0eaf33e0c83a4280423d60670ffb1450a9321519).

## sending an error

The developer can send an error like this:

```
ReportErrorToServer({
    developerComment: 'User clicked a button',
    errorObject: new Error('this was the error ;-)'),
    additionalInfo: {
      address: '0x123456789',
   },
});
```

This creates an error report with the following structure:

```
{
   "comment":"User clicked a button",
   "additionalInfo":"",
   "errorObject":{
      "message":"this was the error ;-)",
      "stack":"Error: this was the error ;-)\n    at Object.reportError [as onPress] (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:256003:20)\n    at Object.touchableHandlePress (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:10011:40)\n    at Object._performSideEffectsForTransition (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:9417:16)\n    at Object._receiveSignal (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:9343:14)\n    at Object.touchableHandleResponderRelease (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:9222:12)\n    at Object.invokeGuardedCallbackImpl (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:22033:16)\n    at invokeGuardedCallback (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:22124:37)\n    at invokeGuardedCallbackAndCatchFirstError (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:22128:31)\n    at executeDispatch (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:22322:9)\n    at executeDispatchesInOrder (blob:http://localhost:8081/bc7ba6c8-1dd4-4c0f-b8e2-0921cc4d3244:22342:11)"
   },
   "userId":"DooqqNxBtN",
   "username":"381730f3-042d-402e-85ea-3e984184ff76",
   "platform":"Android",
   "appVersion":"1.4.2"
}
```
I am unsure if the stack trace will be helpful. My thinking is that we could put identifying information in the `developerComment` section that would find the error quickly.

If there is an `error.code`, as many of the server calls have, that will also be included in the `errorObject`.

## future

In the future, an error could be reported by the user, or a modal could be created with an input box for the user to add additional details. This could be a new parameter in the object that is sent. 
