### PR TITLE
chore: update readme setup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a multi-cryptocurrency wallet application. Supports both english and spa
 ## Prerequisite
 
 ### To run on Android
-1. In order to run this App in Android Simulator, **Android Studio** needs to be installed. Please refer to [https://developer.android.com/studio](https://developer.android.com/studio)
+1. In order to run this App in Android Simulator, **Android Studio** needs to be installed with Android SKD 10 (Api level 29). Please refer to [https://developer.android.com/studio](https://developer.android.com/studio)
 1. Open Android Studio, create a device via `Tools > AVD Manager > Create Virtual Device`. After downloading required dependencies, start the device by clicking on Play icon.
 1. Now we are testing if you can invoke `adb` in terminial. This is for running rWallet Android App on Android virtual device.
     1. Since we already have Android Studio installed we can add `platform-tools` to path
@@ -22,7 +22,7 @@ This is a multi-cryptocurrency wallet application. Supports both english and spa
         emulator-5554	device
         ```
 ### To run on iOS Devices
-1. XCode needs to be installed. iOS simulator will be install along with XCode.
+1. XCode needs to be installed (v11.x). iOS simulator will be install along with XCode.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,19 @@ This is a multi-cryptocurrency wallet application. Supports both english and spa
         List of devices attached
         emulator-5554	device
         ```
+       
+**Note:** When  `syncing project with gradle files` using Android SKD 11, it throws the following error:
+```
+No variants found for ':@imstar15_react-native-firebase'. Check build files to ensure at least one variant exists. at:
+```
+
 ### To run on iOS Devices
 1. XCode needs to be installed (v11.x). iOS simulator will be install along with XCode.
+
+**Note:** When running  `npm install ` with xCode 12.x it throws the following error:
+```
+ReferenceError: globalThis is not defined #2795
+```
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ No variants found for ':@imstar15_react-native-firebase'. Check build files to e
 ```
 
 ### To run on iOS Devices
-1. XCode needs to be installed (v11.x). iOS simulator will be install along with XCode.
+1. XCode needs to be installed (v11.x). iOS simulator will be installed along with XCode.
 
 **Note:** When running  `npm install ` with xCode 12.x it throws the following error:
 ```


### PR DESCRIPTION
- Android SKD 10 (Api level 29)
- xCode v11.x required. Version 12 doesn't work

Error when using SDK 11 ->
![android-sdk11-error](https://user-images.githubusercontent.com/85146/117726661-1fba7b80-b1a4-11eb-9061-8ce5fe182fc2.png)

Error when using xCode 12.x ->
![xCode-error](https://user-images.githubusercontent.com/85146/117726672-221cd580-b1a4-11eb-9e24-83c5aedd996b.png)

