### PR TITLE
Fix double

### DIFF
--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -393,11 +393,11 @@ class RNStorage {
 
   getUserPassword = () => RNStorage.secureGet(SECURE_USER_PASSWORD)
 
-  setLastPasscodeAttempt = (timestamp) => RNStorage.secureSet(SECURE_LAST_WRONG_PASSCODE_TIMESTAMP, timestamp);
+  setLastPasscodeAttempt = (timestamp) => RNStorage.secureSet(SECURE_LAST_WRONG_PASSCODE_TIMESTAMP, timestamp.toString());
 
   getLastPasscodeAttempt = () => RNStorage.secureGet(SECURE_LAST_WRONG_PASSCODE_TIMESTAMP);
 
-  setWrongPasscodeCounter = (count) => RNStorage.secureSet(SECURE_WRONG_PASSCODE_COUNTER, count);
+  setWrongPasscodeCounter = (count) => RNStorage.secureSet(SECURE_WRONG_PASSCODE_COUNTER, count.toString());
 
   getWrongPasscodeCounter = () => RNStorage.secureGet(SECURE_WRONG_PASSCODE_COUNTER);
 }

--- a/src/components/common/passcode/passcode.modal.verify.js
+++ b/src/components/common/passcode/passcode.modal.verify.js
@@ -43,7 +43,12 @@ class VerifyPasscodeModal extends PureComponent {
     if (this.wrongAttemptsCounter < WRONG_ATTEMPTS_STEPS.step1.maxAttempts) {
       return;
     }
-    const lastAttemptTimestamp = parseInt(await storage.getLastPasscodeAttempt(), 10);
+    const lastPasscodeStorage = await storage.getLastPasscodeAttempt();
+    if (!lastPasscodeStorage || lastPasscodeStorage === '0') {
+      return;
+    }
+
+    const lastAttemptTimestamp = parseInt(lastPasscodeStorage, 10);
     const msSinceLastAttempt = Date.now() - lastAttemptTimestamp;
     const { waitingMinutes } = getClosestStep({ numberOfAttempts: this.wrongAttemptsCounter });
     const milliseconds = waitingMinutes * 1000 * 60 - msSinceLastAttempt;

--- a/src/components/common/passcode/wrongPasscodeUtils.js
+++ b/src/components/common/passcode/wrongPasscodeUtils.js
@@ -21,7 +21,7 @@ export const WRONG_ATTEMPTS_STEPS = {
 
 export const clearWrongAttempts = () => {
   try {
-    storage.setLastPasscodeAttempt();
+    storage.setLastPasscodeAttempt(0);
     storage.setWrongPasscodeCounter(0);
   } catch (error) {
     console.error('Error cleaning wrong attempts', error);


### PR DESCRIPTION
Fixes issue where java was failing on converting double to string.

1. Convert integers to strings before saving them to storage.
2. Check on return if the key exists, then convert to double or assume 0
3. When writing data, give value. This was the line that was failing.