### PR TITLE
fix: fix token estimation of fees and transfer

### DIFF
--- a/src/common/transaction/index.js
+++ b/src/common/transaction/index.js
@@ -79,7 +79,7 @@ export default class Transaction {
         result = await rbtc.signTransaction(this.rawTransaction, privateKey);
       }
     } catch (e) {
-      console.log('Transaction.processTransaction err: ', e.message);
+      console.log('Transaction.processTransaction err: ', e);
       throw e;
     }
     console.log('Transaction.processTransaction finished, result: ', result);


### PR DESCRIPTION
## Context
When trying to send a tx using a Token, an error occurred saying "Internal Error".

## Issue
During the process of building the tx, we mix inside the code the use of "checksum vs lowercase". In this case, *I think* it was an incompatibility between library checksums, but the real matter it is that we don't need it in order to operate with the network. Checksums are only needed for user, when interacting with addresses as a second factor of verification. 

## Final fix
As this fix doesn't actually change that verification (it is made in another level), we send lowercase address as the final address in the transaction.

