### PR TITLE
fix: filter duplicated tokens by contract address, not by symbol

### DIFF
--- a/src/common/wallet/wallet.js
+++ b/src/common/wallet/wallet.js
@@ -235,7 +235,7 @@ export default class Wallet extends BasicWallet {
     let coin = null;
 
     // If the token already exists, an exception is thrown.
-    const foundCoin = _.find(this.coins, { symbol, type });
+    const foundCoin = contractAddress && _.find(this.coins, { contractAddress });
     if (foundCoin) {
       throw new Error('err.exsistedtoken');
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85146/125534923-859701bc-21be-40ac-9bc4-8f196af918a8.png)

Closes https://github.com/rsksmart/rwallet/issues/481