### PR TITLE
Fix BRZ and TTE metadata

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -105,7 +105,7 @@ export const ASSETS_CONTRACT = {
     Mainnet: '0xaf8C226013BDc4b3AACe1F8060Db645b3F5E53FC',
   },
   TTE: {
-    Testnet: '0xe30f71ade0f4af9e134fb8f480bc82d15d582d99',
+    Testnet: '0xe30f71aDE0F4af9e134fb8F480BC82D15d582D99',
   },
   BRZ: {
     Testnet: '0x06d164E8d6829E1dA028A4F745d330Eb764Dd3aC',

--- a/src/common/wallet/cointype.js
+++ b/src/common/wallet/cointype.js
@@ -89,7 +89,7 @@ const coinType = {
     type: 'Mainnet',
     symbol: 'BRZ',
     contractAddress: ASSETS_CONTRACT.BRZ.Mainnet,
-    precision: 18,
+    precision: 4,
   },
   CustomToken: {
     networkId: 30,
@@ -184,7 +184,7 @@ const coinType = {
     type: 'Testnet',
     symbol: 'TTE',
     contractAddress: ASSETS_CONTRACT.TTE.Testnet,
-    precision: 18,
+    precision: 2,
   },
    BRZTestnet: {
     networkId: 31,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Having wrong decimals hid the token in the landing

## Motivation and Context
- Introduced on #720 and #721 

## How Has This Been Tested?
- The test process described on #720 is after this change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] fix: bug fixes, e.g. fix Button color on DarkTheme.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.


* **Other information**:
* The `precision` or `decimals` value must be fetch from the contract. Metamask does this in 'Add custom token' feature

<img width="343" alt="Screen Shot 2021-08-02 at 18 54 22" src="https://user-images.githubusercontent.com/36084092/127928766-7cd5b113-927b-4830-a2be-df700f744465.png">


* **SCREENSHOTS**:
* 
![Screen Shot 2021-08-02 at 17 57 02](https://user-images.githubusercontent.com/36084092/127928631-699ec803-bd00-4af9-8200-6e11d9379230.png)

